### PR TITLE
Redesign chat interface with modern turn-by-turn UI and streamline codebase

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,473 +1,427 @@
-# Filename: app.py
+# app.py — Streamlined main application entry point.
+
+import io
+import datetime
+import logging
+import os
+from typing import Dict, Any, Optional
 
 import streamlit as st
-import os
-import logging
-from dotenv import load_dotenv # Keep load_dotenv here, call early
-import datetime
-import json
-from typing import List, Dict, Any, Optional
+from dotenv import load_dotenv
 
-# --- Load Environment Variables ---
-# Call early, before other imports that might rely on env vars (like auth)
 load_dotenv()
 
-# --- Import Authentication Module ---
-try:
-    import auth # Import the new authentication module
-except ImportError:
-    st.error("Fatal Error: Authentication module (`auth.py`) not found.")
-    st.stop()
-
-# Configure root logger
-# Include microseconds for potentially rapid status updates
-logging.basicConfig(level=logging.INFO, format='%(asctime)s.%(msecs)03d - %(name)s - %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+# ---------------------------------------------------------------------------
+# Logging — single basicConfig call for the whole process
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s.%(msecs)03d - %(name)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
 logger = logging.getLogger(__name__)
 
-# --- Main App Execution ---
+# ---------------------------------------------------------------------------
+# Authentication gate
+# ---------------------------------------------------------------------------
+try:
+    import auth
+except ImportError:
+    st.error("Fatal: `auth.py` not found.")
+    st.stop()
 
-# Initialize authentication status if it doesn't exist in session state
 if "authenticated" not in st.session_state:
     st.session_state.authenticated = False
 
-# Run the password check using the auth module.
 if not auth.check_password():
     st.stop()
 
-# --- !!! --- APPLICATION CODE BELOW RUNS ONLY IF AUTHENTICATED --- !!! ---
-
-# --- Local Imports (needed only after authentication) ---
+# ---------------------------------------------------------------------------
+# Authenticated imports
+# ---------------------------------------------------------------------------
 try:
     from direction import Director
     import gui
-    from translator import translate_conversation # Import the new translator function
+    from translator import translate_conversation
 except ImportError as e:
-    st.error(f"Critical Error: Failed to import local modules post-authentication. Details: {e}")
-    logging.exception("Failed to import local modules post-authentication.")
-    st.stop()
-except Exception as e:
-    st.error(f"Critical Error during initial imports post-authentication: {e}")
-    logging.exception("Failed during initial imports post-authentication.")
+    st.error(f"Failed to import modules: {e}")
+    logger.exception("Module import failed.")
     st.stop()
 
-# --- Configuration (specific to the authenticated app) ---
-LOG_DIR = "logs"
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
 DEFAULT_NUM_ROUNDS = 3
-DEFAULT_CONVERSATION_MODE = 'Philosophy'
-DEFAULT_MODERATOR_CONTROL_MODE = 'AI Moderator' # 'AI Moderator' or 'User as Moderator (Guidance)'
+DEFAULT_CONVERSATION_MODE = "Philosophy"
+DEFAULT_MODERATOR_CONTROL = "AI Moderator"
 
-# --- Log File Handling ---
-def initialize_log(num_rounds_for_log: int) -> bool:
-    log_base_filename = f"streamlit_conversation_log_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
-    st.session_state.current_log_filename = log_base_filename
-    st.session_state.log_content = []
-    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    selected_mode = st.session_state.get('conversation_mode', DEFAULT_CONVERSATION_MODE)
-    moderator_control = st.session_state.get('moderator_control_mode', DEFAULT_MODERATOR_CONTROL_MODE)
-    bypass_moderator = st.session_state.get('bypass_moderator_cb', False)
-
-    st.session_state.log_content.append(f"Streamlit Conversation Log - {timestamp}")
-    st.session_state.log_content.append(f"Requested Rounds: {num_rounds_for_log}")
-    st.session_state.log_content.append(f"Conversation Mode: {selected_mode}")
-    if bypass_moderator:
-        st.session_state.log_content.append(f"Moderation: Bypassed")
-    else:
-        st.session_state.log_content.append(f"Moderator Control: {moderator_control}")
-    st.session_state.log_content.append("========================================")
-    st.session_state.log_content.append("")
-    logger.info(f"Initialized in-memory log for download: {log_base_filename} (Mode: '{selected_mode}', ModCtrl: '{moderator_control}', Bypass: {bypass_moderator})")
-    try:
-        os.makedirs(LOG_DIR, exist_ok=True)
-        local_log_path = os.path.join(LOG_DIR, log_base_filename)
-        st.session_state.local_log_file_handle = open(local_log_path, 'w', encoding='utf-8')
-        for line in st.session_state.log_content:
-            st.session_state.local_log_file_handle.write(line + "\n")
-        st.session_state.local_log_file_handle.flush()
-        logger.info(f"Also writing log to local file: {local_log_path}")
-    except Exception as e:
-        logger.warning(f"Could not open local log file {log_base_filename}: {e}")
-        st.session_state.local_log_file_handle = None
-    return True
-
-def write_log(message_dict: Dict[str, Any]):
-    if 'log_content' not in st.session_state or st.session_state.log_content is None:
-        if st.session_state.get('conversation_started_for_log', False):
-             logger.warning("write_log called but log_content is None. Re-initializing log.")
-        else:
-             logger.debug("write_log called but log not initialized or already closed. Skipping.")
-             return
-
-    try:
-        role = message_dict.get('role', 'system').upper()
-        content = message_dict.get('content', '')
-        log_line = ""
-        
-        if role == 'SYSTEM':
-             content_str = str(content).strip() if content is not None else ""
-             if content_str.startswith(("MODERATOR CONTEXT", "MODERATOR EVALUATION", "Error:", "USER GUIDANCE FOR")):
-                 log_line = f"{content_str}"
-             else:
-                 log_line = f"SYSTEM: {content_str}"
-        elif role == 'USER': # This is the initial user prompt
-            log_line = f"USER PROMPT: {str(content)}"
-        else: # Philosopher roles
-            log_line = f"{role}: {str(content)}"
-
-        separator = "----------------------------------------"
-        st.session_state.log_content.append(log_line)
-        st.session_state.log_content.append(separator)
-
-        if st.session_state.get('local_log_file_handle') and not st.session_state.local_log_file_handle.closed:
-            try:
-                st.session_state.local_log_file_handle.write(log_line + "\n")
-                st.session_state.local_log_file_handle.write(separator + "\n")
-                st.session_state.local_log_file_handle.flush()
-            except Exception as e: logger.error(f"Error writing to local log file: {e}", exc_info=True)
-    except Exception as e:
-        logger.error(f"Error preparing log entry: {e}", exc_info=True)
-        if 'current_status' in st.session_state and st.session_state.current_status != "Error writing to log.":
-             st.session_state.current_status = "Error writing to log."; st.toast("Error writing to log.", icon="⚠️")
-
-
-def close_log():
-    if 'log_content' in st.session_state and st.session_state.log_content:
-        if isinstance(st.session_state.log_content, list) and st.session_state.log_content:
-             if not st.session_state.log_content[-1].strip().endswith("--- Log End ---"):
-                  st.session_state.log_content.append("\n--- Log End ---")
-        elif isinstance(st.session_state.log_content, list) and not st.session_state.log_content:
-             pass
-
-    if 'local_log_file_handle' in st.session_state and st.session_state.local_log_file_handle:
-        if not st.session_state.local_log_file_handle.closed:
-             log_filename = st.session_state.get('current_log_filename', 'Unknown Local Log File')
-             try:
-                 st.session_state.local_log_file_handle.write("\n--- Log file closed ---\n")
-                 st.session_state.local_log_file_handle.close()
-                 logger.info(f"Closed local log file: {log_filename}")
-             except Exception as e: logger.error(f"Error closing local log file {log_filename}: {e}")
-        st.session_state.local_log_file_handle = None
-    st.session_state.conversation_started_for_log = False
-
-
-# --- Initialize Session State ---
-default_app_values = {
-    'messages': [], 'director_instance': None, 'current_status': "Ready.",
-    'log_content': None, 'current_log_filename': None, 'local_log_file_handle': None,
-    'show_monologue_cb': False, 'show_moderator_cb': False, 'bypass_moderator_cb': False,
-    'starting_philosopher': 'Socrates', 'num_rounds': DEFAULT_NUM_ROUNDS,
-    'conversation_mode': DEFAULT_CONVERSATION_MODE, 'run_conversation_flag': False,
-    'conversation_completed': False, 'conversation_started_for_log': False,
-    'prompt_overrides': {},
-    'moderator_control_mode': DEFAULT_MODERATOR_CONTROL_MODE,
-    'awaiting_user_guidance': False,
-    'ai_summary_for_guidance_input': None,
-    'next_speaker_for_guidance': None,
-    'director_resume_state': None
+# ---------------------------------------------------------------------------
+# Session state initialisation (one flat dict, no file handles)
+# ---------------------------------------------------------------------------
+_DEFAULTS: Dict[str, Any] = {
+    "messages": [],
+    "director_instance": None,
+    "current_status": "Ready.",
+    "log_content": None,
+    "current_log_filename": None,
+    "show_monologue_cb": False,
+    "show_moderator_cb": False,
+    "bypass_moderator_cb": False,
+    "starting_philosopher": "Socrates",
+    "num_rounds": DEFAULT_NUM_ROUNDS,
+    "conversation_mode": DEFAULT_CONVERSATION_MODE,
+    "run_conversation_flag": False,
+    "conversation_completed": False,
+    "prompt_overrides": {},
+    "moderator_control_mode": DEFAULT_MODERATOR_CONTROL,
+    "awaiting_user_guidance": False,
+    "ai_summary_for_guidance_input": None,
+    "next_speaker_for_guidance": None,
+    "director_resume_state": None,
 }
-for key, default_value in default_app_values.items():
-    if key not in st.session_state: st.session_state[key] = default_value
+for key, default in _DEFAULTS.items():
+    if key not in st.session_state:
+        st.session_state[key] = default
 
 if st.session_state.director_instance is None:
     try:
         st.session_state.director_instance = Director()
-        logger.info("Director instance created successfully post-authentication.")
+        logger.info("Director created.")
     except Exception as e:
-        st.error(f"Error initializing Director post-authentication: {e}")
-        logger.exception("Director initialization failed post-authentication.")
+        st.error(f"Error initialising Director: {e}")
+        logger.exception("Director init failed.")
         st.stop()
 
-# --- Render Authenticated UI ---
+
+# ---------------------------------------------------------------------------
+# Logging helpers (in-memory only — no open file handles in session state)
+# ---------------------------------------------------------------------------
+
+def _init_log(num_rounds: int) -> None:
+    """Create a fresh in-memory log buffer."""
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    st.session_state.current_log_filename = f"conversation_log_{ts}.txt"
+    header_lines = [
+        f"Conversation Log — {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+        f"Rounds: {num_rounds}",
+        f"Mode: {st.session_state.get('conversation_mode', DEFAULT_CONVERSATION_MODE)}",
+        f"Moderator: {'Bypassed' if st.session_state.get('bypass_moderator_cb') else st.session_state.get('moderator_control_mode', DEFAULT_MODERATOR_CONTROL)}",
+        "=" * 40,
+        "",
+    ]
+    st.session_state.log_content = header_lines
+    logger.info(f"Log initialised: {st.session_state.current_log_filename}")
+
+
+def _write_log(msg: Dict[str, Any]) -> None:
+    """Append a message dict to the in-memory log."""
+    log = st.session_state.get("log_content")
+    if not isinstance(log, list):
+        return
+    role = msg.get("role", "system").upper()
+    content = str(msg.get("content", ""))
+    if role == "SYSTEM":
+        line = content.strip()
+    elif role == "USER":
+        line = f"USER PROMPT: {content}"
+    else:
+        line = f"{role}: {content}"
+    log.append(line)
+    log.append("-" * 40)
+
+
+def _close_log() -> None:
+    """Mark the log as finished."""
+    log = st.session_state.get("log_content")
+    if isinstance(log, list) and log and not log[-1].strip().endswith("--- Log End ---"):
+        log.append("\n--- Log End ---")
+
+
+# ---------------------------------------------------------------------------
+# State reset helper
+# ---------------------------------------------------------------------------
+
+def _reset_conversation() -> None:
+    """Reset all conversation-related state in one place."""
+    st.session_state.messages = []
+    st.session_state.current_status = "Ready."
+    st.session_state.log_content = None
+    st.session_state.current_log_filename = None
+    st.session_state.conversation_completed = False
+    st.session_state.awaiting_user_guidance = False
+    st.session_state.ai_summary_for_guidance_input = None
+    st.session_state.next_speaker_for_guidance = None
+    st.session_state.director_resume_state = None
+    st.session_state.pop("run_conversation_flag", None)
+    st.session_state.pop("current_run_mode", None)
+    _close_log()
+    logger.info("Conversation state reset.")
+
+
+# ---------------------------------------------------------------------------
+# Conversation runners
+# ---------------------------------------------------------------------------
+
+def _run_initial_conversation(prompt: str) -> None:
+    """Start a new conversation from an initial user prompt."""
+    num_rounds = st.session_state.get("num_rounds", DEFAULT_NUM_ROUNDS)
+    mode = st.session_state.get("current_run_mode", DEFAULT_CONVERSATION_MODE)
+    starter = st.session_state.get("starting_philosopher", "Socrates")
+    bypass = st.session_state.get("bypass_moderator_cb", False)
+    mod_ctrl = st.session_state.get("moderator_control_mode", DEFAULT_MODERATOR_CONTROL)
+
+    run_moderated = not bypass
+    mod_type = "ai"
+    if mod_ctrl == "User as Moderator (Guidance)" and run_moderated:
+        mod_type = "user_guidance"
+
+    director: Director = st.session_state.director_instance
+
+    final_status = "Error: conversation did not complete."
+    try:
+        st.session_state.current_status = f"Philosophers conferring ({mode} mode)..."
+        with st.spinner(f"Philosophers conferring ({mode} mode)..."):
+            gen_msgs, final_status, success, resume_state, guidance_data = (
+                director.run_conversation_streamlit(
+                    initial_input=prompt,
+                    num_rounds=num_rounds,
+                    starting_philosopher=starter,
+                    run_moderated=run_moderated,
+                    mode=mode,
+                    moderator_type=mod_type,
+                )
+            )
+            logger.info(f"Director finished. success={success}, status={final_status}")
+
+        st.session_state.current_status = final_status
+        st.session_state.messages.extend(gen_msgs)
+        for m in gen_msgs:
+            _write_log(m)
+
+        if final_status == "WAITING_FOR_USER_GUIDANCE":
+            st.session_state.awaiting_user_guidance = True
+            st.session_state.ai_summary_for_guidance_input = guidance_data["ai_summary"]
+            st.session_state.next_speaker_for_guidance = guidance_data["next_speaker_name"]
+            st.session_state.director_resume_state = resume_state
+            st.session_state.current_status = (
+                f"Waiting for your guidance for {guidance_data['next_speaker_name']}..."
+            )
+        elif success:
+            st.session_state.conversation_completed = True
+            st.session_state.director_resume_state = None
+            _maybe_translate(mode)
+            _close_log()
+        else:
+            st.session_state.conversation_completed = True
+            st.session_state.director_resume_state = None
+            _close_log()
+    except Exception as e:
+        logger.exception("Conversation error.")
+        st.error(f"Conversation error: {e}")
+        st.session_state.current_status = "Critical error during conversation."
+        st.session_state.director_resume_state = None
+        _close_log()
+    finally:
+        if final_status != "WAITING_FOR_USER_GUIDANCE":
+            st.session_state.pop("current_run_mode", None)
+        st.rerun()
+
+
+def _resume_conversation(user_guidance: str) -> None:
+    """Resume a user-guided conversation with the provided guidance text."""
+    director: Director = st.session_state.director_instance
+    resume_state = st.session_state.director_resume_state
+    mode = resume_state.get("mode", DEFAULT_CONVERSATION_MODE) if resume_state else DEFAULT_CONVERSATION_MODE
+
+    final_status = "Error: resume did not complete."
+    try:
+        with st.spinner(f"Philosophers conferring ({mode} mode) with your guidance..."):
+            gen_msgs, final_status, success, new_resume, guidance_data = (
+                director.resume_conversation_streamlit(resume_state, user_provided_guidance=user_guidance)
+            )
+            logger.info(f"Director resumed. success={success}, status={final_status}")
+
+        st.session_state.current_status = final_status
+        st.session_state.messages.extend(gen_msgs)
+        for m in gen_msgs:
+            _write_log(m)
+
+        if final_status == "WAITING_FOR_USER_GUIDANCE":
+            st.session_state.awaiting_user_guidance = True
+            st.session_state.ai_summary_for_guidance_input = guidance_data["ai_summary"]
+            st.session_state.next_speaker_for_guidance = guidance_data["next_speaker_name"]
+            st.session_state.director_resume_state = new_resume
+            st.session_state.current_status = (
+                f"Waiting for your guidance for {guidance_data['next_speaker_name']}..."
+            )
+        elif success:
+            st.session_state.conversation_completed = True
+            st.session_state.director_resume_state = None
+            _maybe_translate(mode)
+            _close_log()
+        else:
+            st.session_state.conversation_completed = True
+            st.session_state.director_resume_state = None
+            _close_log()
+    except Exception as e:
+        logger.exception("Resume error.")
+        st.error(f"Resume error: {e}")
+        st.session_state.current_status = "Critical error during resume."
+        st.session_state.director_resume_state = None
+        _close_log()
+    finally:
+        if final_status != "WAITING_FOR_USER_GUIDANCE":
+            st.session_state.pop("current_run_mode", None)
+        st.rerun()
+
+
+def _maybe_translate(mode: str) -> None:
+    """If translated output is selected, run the translator."""
+    if st.session_state.get("output_style") != "Translated Text":
+        return
+    try:
+        with st.spinner("Translating conversation..."):
+            original = st.session_state.messages[:]
+            translated = translate_conversation(original)
+        st.session_state.messages = [
+            {"role": "system", "content": f"### Translated Conversation\n\n---\n\n{translated}"}
+        ]
+        log = st.session_state.get("log_content")
+        if isinstance(log, list):
+            log.append("\n\n--- TRANSLATED CONVERSATION ---")
+            log.append(translated)
+    except Exception as e:
+        logger.error(f"Translation failed: {e}", exc_info=True)
+        st.error(f"Translation failed: {e}")
+
+
+# ---------------------------------------------------------------------------
+# UI Rendering
+# ---------------------------------------------------------------------------
+
+# Inject CSS once
+gui.inject_chat_css()
+
+# Sidebar
 try:
     model_info = gui.get_model_info_from_config()
     gui.display_sidebar(model_info)
-except Exception as e: st.error(f"Error rendering sidebar: {e}"); logger.exception("Error during sidebar rendering.")
-try:
-    gui.display_header()
-    gui.display_conversation(st.session_state.messages)
-except Exception as e: st.error(f"Error rendering main UI components: {e}"); logger.exception("Error during main UI rendering.")
+except Exception as e:
+    st.error(f"Sidebar error: {e}")
+    logger.exception("Sidebar rendering failed.")
 
-if st.session_state.get('show_monologue_cb', False):
-    with st.expander("Internal Monologue / Debug"):
-        monologue_found = False
-        messages_to_check = st.session_state.get('messages')
-        if isinstance(messages_to_check, list):
-             for message in messages_to_check:
-                 monologue = None; role = 'Unknown'
-                 if isinstance(message, dict):
-                      monologue = message.get('monologue'); role = message.get('role', 'System')
-                 if monologue:
-                      monologue_found = True; st.markdown(f"**[{role}] Thought:**"); st.text(str(monologue)); st.divider()
-        if not monologue_found: st.caption("No monologue entries found.")
+# Header
+gui.display_header()
 
-status_placeholder = st.empty()
-with status_placeholder.container():
-    current_status_text = st.session_state.get('current_status', 'Status unavailable.')
-    timestamp_str = datetime.datetime.now().strftime('%H:%M:%S')
-    st.caption(f"[{timestamp_str}] {current_status_text}")
+# Conversation display
+gui.display_conversation(
+    messages=st.session_state.messages,
+    conversation_completed=st.session_state.get("conversation_completed", False),
+    awaiting_guidance=st.session_state.get("awaiting_user_guidance", False),
+    next_speaker_for_guidance=st.session_state.get("next_speaker_for_guidance", ""),
+    num_rounds=st.session_state.get("num_rounds", DEFAULT_NUM_ROUNDS),
+    mode=st.session_state.get("conversation_mode", DEFAULT_CONVERSATION_MODE),
+)
 
+# Internal monologue expander
+gui.display_monologue(st.session_state.messages)
 
-# --- Determine Chat Input Prompt ---
-chat_input_prompt_text = "Enter your initial question..."
-if st.session_state.get('awaiting_user_guidance', False):
-    next_speaker = st.session_state.get('next_speaker_for_guidance', 'the next philosopher')
-    summary_for_user = st.session_state.get('ai_summary_for_guidance_input', '')
-    if summary_for_user:
-        pass
-    chat_input_prompt_text = f"Enter your GUIDANCE for {next_speaker} (or type 'auto' for AI guidance this turn):"
+# Status line
+ts = datetime.datetime.now().strftime("%H:%M:%S")
+status_text = st.session_state.get("current_status", "Ready.")
+st.caption(f"[{ts}] {status_text}")
 
-# --- Handle User Input (Initial Prompt or User Guidance) ---
-prompt: Optional[str] = st.chat_input(chat_input_prompt_text, key="main_chat_input")
+# ---------------------------------------------------------------------------
+# Chat input handling
+# ---------------------------------------------------------------------------
+
+if st.session_state.get("awaiting_user_guidance"):
+    next_spk = st.session_state.get("next_speaker_for_guidance", "the next philosopher")
+    input_prompt = f"Enter guidance for {next_spk} (or type 'auto' for AI guidance):"
+else:
+    input_prompt = "Enter your question to start a philosophical dialogue..."
+
+prompt: Optional[str] = st.chat_input(input_prompt, key="main_chat_input")
 
 if prompt:
-    if st.session_state.get('awaiting_user_guidance', False):
-        # --- This is User-Provided Guidance ---
-        logger.info(f"User guidance received for {st.session_state.get('next_speaker_for_guidance', 'N/A')}: '{prompt[:50]}...'")
-        st.session_state.current_status = "Processing your guidance..."
-        
-        user_guidance_message_content = f"USER GUIDANCE FOR {st.session_state.next_speaker_for_guidance}:\n{prompt}"
+    if st.session_state.get("awaiting_user_guidance"):
+        # ── User guidance path ──
+        logger.info(f"User guidance: '{prompt[:50]}...'")
+        guidance_label = st.session_state.get("next_speaker_for_guidance", "N/A")
+        guidance_content = f"USER GUIDANCE FOR {guidance_label}:\n{prompt}"
         if prompt.strip().lower() == "auto":
-            user_guidance_message_content = f"SYSTEM: User opted for AI guidance for {st.session_state.next_speaker_for_guidance} this turn."
-        
-        user_guidance_message: Dict[str, Any] = {"role": "system", "content": user_guidance_message_content, "monologue": None}
-        st.session_state.messages.append(user_guidance_message)
-        write_log(user_guidance_message)
-
+            guidance_content = f"SYSTEM: User opted for AI guidance for {guidance_label} this turn."
+        st.session_state.messages.append({"role": "system", "content": guidance_content, "monologue": None})
+        _write_log({"role": "system", "content": guidance_content})
         st.session_state.awaiting_user_guidance = False
-        
-        director = st.session_state.director_instance
-        if director and st.session_state.director_resume_state:
-            try:
-                current_mode_resuming = st.session_state.director_resume_state.get('mode', DEFAULT_CONVERSATION_MODE)
-                with st.spinner(f"Philosophers conferring ({current_mode_resuming} mode) with your guidance..."):
-                    logger.info(f"Calling Director to resume with user guidance. Mode='{current_mode_resuming}'")
-                    
-                    gen_msgs, final_stat, success, resume_state, guidance_data = director.resume_conversation_streamlit(
-                        st.session_state.director_resume_state,
-                        user_provided_guidance=prompt
-                    )
-                    logger.info(f"Director resumed. Success: {success}. Status: {final_stat}")
 
-                st.session_state.current_status = final_stat
-                st.session_state.messages.extend(gen_msgs)
-                for msg in gen_msgs: write_log(msg)
-
-                if final_stat == "WAITING_FOR_USER_GUIDANCE":
-                    st.session_state.awaiting_user_guidance = True
-                    st.session_state.ai_summary_for_guidance_input = guidance_data['ai_summary']
-                    st.session_state.next_speaker_for_guidance = guidance_data['next_speaker_name']
-                    st.session_state.director_resume_state = resume_state
-                    st.session_state.current_status = f"Waiting for your guidance for {st.session_state.next_speaker_for_guidance}..."
-                elif success:
-                    st.toast(f"Conversation continued ({current_mode_resuming} mode).", icon="✅")
-                    st.session_state.conversation_completed = True
-                    st.session_state.director_resume_state = None
-                    close_log()
-                else:
-                    st.toast(f"Conversation ended: {final_stat}", icon="⚠️")
-                    st.session_state.conversation_completed = True
-                    st.session_state.director_resume_state = None
-                    close_log()
-
-            except Exception as e:
-                error_msg = f"An unexpected error occurred during conversation resume: {e}"
-                st.error(error_msg); logger.exception(error_msg)
-                st.session_state.current_status = "Critical error during conversation resume."
-                st.session_state.conversation_completed = False
-                st.session_state.director_resume_state = None
-                close_log()
-            finally:
-                if final_stat != "WAITING_FOR_USER_GUIDANCE":
-                    if 'current_run_mode' in st.session_state: del st.session_state.current_run_mode
-                st.rerun()
+        if st.session_state.director_instance and st.session_state.director_resume_state:
+            _resume_conversation(prompt)
         else:
-            st.error("Error: Director or resume state not available. Cannot resume.")
-            logger.error("Director or resume state missing, cannot resume user-guided conversation.")
-            st.session_state.current_status = "Error: Cannot resume conversation."
-            st.session_state.director_resume_state = None
-            close_log()
+            st.error("Cannot resume: Director or resume state unavailable.")
+            _close_log()
             st.rerun()
-
     else:
-        # --- This is an Initial User Prompt ---
-        logger.info(f"User input received: '{prompt[:50]}...'")
-        st.session_state.current_status = "Processing..."
-        st.session_state.messages = []
-        st.session_state.conversation_completed = False
-        st.session_state.log_content = None
-        st.session_state.current_log_filename = None
-        st.session_state.awaiting_user_guidance = False
-        st.session_state.ai_summary_for_guidance_input = None
-        st.session_state.next_speaker_for_guidance = None
-        st.session_state.director_resume_state = None
-        close_log() 
-        
-        num_rounds_selected = st.session_state.get('num_rounds', DEFAULT_NUM_ROUNDS)
-        selected_mode = st.session_state.get('conversation_mode', DEFAULT_CONVERSATION_MODE)
-        
-        st.session_state.conversation_started_for_log = True
-        if not initialize_log(num_rounds_selected):
-            st.session_state.current_status = "Log initialization failed. Cannot proceed."
-            st.rerun()
-        else:
-            user_message: Dict[str, Any] = {"role": "user", "content": prompt, "monologue": None}
-            st.session_state.messages.append(user_message)
-            write_log(user_message)
-            st.session_state.run_conversation_flag = True
-            st.session_state.current_run_mode = selected_mode
-            st.rerun()
+        # ── New conversation path ──
+        logger.info(f"New prompt: '{prompt[:50]}...'")
+        _reset_conversation()
+
+        num_rounds = st.session_state.get("num_rounds", DEFAULT_NUM_ROUNDS)
+        mode = st.session_state.get("conversation_mode", DEFAULT_CONVERSATION_MODE)
+
+        _init_log(num_rounds)
+
+        user_msg: Dict[str, Any] = {"role": "user", "content": prompt, "monologue": None}
+        st.session_state.messages.append(user_msg)
+        _write_log(user_msg)
+
+        st.session_state.current_run_mode = mode
+        st.session_state.run_conversation_flag = True
+        st.rerun()
 
 
-# --- Run Conversation if Flag is Set (Initial Start) ---
-if st.session_state.get('run_conversation_flag', False) and not st.session_state.get('awaiting_user_guidance', False) :
-    st.session_state.run_conversation_flag = False # Consume the flag
-    if not st.session_state.messages:
-         logger.error("Run conversation flag set, but message list is empty.")
-         st.error("Cannot start conversation, initial prompt missing.")
-         st.session_state.current_status = "Error: Initial prompt missing."
+# ---------------------------------------------------------------------------
+# Run conversation if flag is set (on the rerun after storing the prompt)
+# ---------------------------------------------------------------------------
+
+if st.session_state.get("run_conversation_flag") and not st.session_state.get("awaiting_user_guidance"):
+    st.session_state.run_conversation_flag = False
+    if st.session_state.messages:
+        _run_initial_conversation(st.session_state.messages[0]["content"])
     else:
-        initial_prompt = st.session_state.messages[0]['content']
-        num_rounds_selected = st.session_state.get('num_rounds', DEFAULT_NUM_ROUNDS)
-        starting_philosopher_selected = st.session_state.get('starting_philosopher', 'Socrates')
-        bypass_moderator_mode = st.session_state.get('bypass_moderator_cb', False)
-        run_moderated_flag = not bypass_moderator_mode
-        
-        moderator_ctrl_mode_display = st.session_state.get('moderator_control_mode', DEFAULT_MODERATOR_CONTROL_MODE)
-        moderator_type_for_director = 'ai'
-        if moderator_ctrl_mode_display == 'User as Moderator (Guidance)':
-            moderator_type_for_director = 'user_guidance'
-        
-        if bypass_moderator_mode:
-            moderator_type_for_director = 'ai'
-
-        current_mode = st.session_state.get('current_run_mode', DEFAULT_CONVERSATION_MODE)
-        director = st.session_state.director_instance
-
-        if director:
-            try:
-                st.session_state.current_status = f"Philosophers conferring ({current_mode} mode)..."
-                with st.spinner(f"Philosophers conferring ({current_mode} mode)..."):
-                     logger.info(f"Calling Director: Mode='{current_mode}', Rounds={num_rounds_selected}, Starter='{starting_philosopher_selected}', Moderated={run_moderated_flag}, ModCtrl='{moderator_type_for_director}'")
-                     
-                     generated_messages, final_status, success, director_resume_state, data_for_user_guidance = director.run_conversation_streamlit(
-                         initial_input=initial_prompt, num_rounds=num_rounds_selected,
-                         starting_philosopher=starting_philosopher_selected, 
-                         run_moderated=run_moderated_flag, 
-                         mode=current_mode,
-                         moderator_type=moderator_type_for_director
-                     )
-                     logger.info(f"Director finished initial run. Success: {success}. Status: {final_status}")
-                
-                st.session_state.current_status = final_status
-                st.session_state.messages.extend(generated_messages)
-                for msg in generated_messages: write_log(msg)
-
-                if final_status == "WAITING_FOR_USER_GUIDANCE":
-                    st.session_state.awaiting_user_guidance = True
-                    st.session_state.ai_summary_for_guidance_input = data_for_user_guidance['ai_summary']
-                    st.session_state.next_speaker_for_guidance = data_for_user_guidance['next_speaker_name']
-                    st.session_state.director_resume_state = director_resume_state
-                    st.session_state.current_status = f"Waiting for your guidance for {st.session_state.next_speaker_for_guidance}..."
-
-                elif success:
-                    st.toast(f"Conversation completed ({current_mode} mode).", icon="✅")
-                    st.session_state.conversation_completed = True
-                    
-                    # --- TRANSLATION LOGIC ---
-                    if st.session_state.get('output_style') == 'Translated Text':
-                        try:
-                            with st.spinner("Translating conversation for a more casual reading..."):
-                                original_messages_for_translation = st.session_state.messages[:]
-                                translated_text = translate_conversation(original_messages_for_translation)
-
-                            # 1. Update the UI display
-                            st.session_state.messages = [{
-                                "role": "system",
-                                "content": f"### Translated Conversation\n\n---\n\n{translated_text}"
-                            }]
-                            
-                            # 2. Update the log content for download
-                            if 'log_content' in st.session_state and isinstance(st.session_state.log_content, list):
-                                # Append the translated text to the existing log content
-                                st.session_state.log_content.append("\n\n--- TRANSLATED CONVERSATION ---")
-                                st.session_state.log_content.append("---------------------------------")
-                                st.session_state.log_content.append(translated_text)
-
-                            st.toast("Translation complete!", icon="✨")
-
-                        except Exception as e:
-                            st.error(f"Failed to translate the conversation: {e}")
-                            logger.error(f"Translation failed: {e}", exc_info=True)
-                    # --- END OF TRANSLATION LOGIC ---
-
-                    st.session_state.director_resume_state = None
-                    close_log()
-
-                else: 
-                    st.toast(f"Conversation ended: {final_status}", icon="⚠️")
-                    st.session_state.conversation_completed = True 
-                    st.session_state.director_resume_state = None
-                    close_log()
-
-            except Exception as e:
-                error_msg = f"An unexpected error occurred during conversation: {e}"
-                st.error(error_msg); logger.exception(error_msg)
-                st.session_state.current_status = "Critical error during conversation."
-                st.session_state.conversation_completed = False
-                st.session_state.director_resume_state = None
-                close_log()
-            finally:
-                if final_status != "WAITING_FOR_USER_GUIDANCE":
-                    if 'current_run_mode' in st.session_state: del st.session_state.current_run_mode
-                st.rerun()
-        else:
-            st.error("Director instance not available."); logger.error("Director instance is None, cannot run conversation.")
-            st.session_state.current_status = "Error: Director not loaded."
-            close_log()
-            st.rerun()
+        st.error("No prompt found.")
+        st.session_state.current_status = "Error: prompt missing."
 
 
-# --- Controls Below Conversation (Authenticated) ---
+# ---------------------------------------------------------------------------
+# Bottom controls
+# ---------------------------------------------------------------------------
+
 st.divider()
 col1, col2 = st.columns([1, 1])
+
 with col1:
     if st.button("Clear & Reset Conversation"):
-        logger.info("Clear Conversation History button clicked.")
-        st.session_state.messages = []
-        st.session_state.current_status = "Ready."
-        st.session_state.log_content = None
-        st.session_state.current_log_filename = None
-        st.session_state.conversation_completed = False
-        st.session_state.awaiting_user_guidance = False
-        st.session_state.ai_summary_for_guidance_input = None
-        st.session_state.next_speaker_for_guidance = None
-        st.session_state.director_resume_state = None
-        close_log()
-        if 'run_conversation_flag' in st.session_state: del st.session_state.run_conversation_flag
-        if 'current_run_mode' in st.session_state: del st.session_state.current_run_mode
-        logger.info("Conversation history and log state cleared.")
+        _reset_conversation()
         st.rerun()
+
 with col2:
-    if st.session_state.get('conversation_completed', False) and st.session_state.get('log_content'):
-        log_filename_to_use = st.session_state.get('current_log_filename', 'conversation_log.txt')
-        log_data = st.session_state.log_content
-        if isinstance(log_data, list):
-            log_data_string = "\n".join(log_data)
-            try:
-                st.download_button(
-                    label="Download Conversation Log", data=log_data_string.encode('utf-8'),
-                    file_name=log_filename_to_use, mime='text/plain'
-                )
-            except Exception as e:
-                logger.error(f"Error creating download button: {e}")
-                st.caption("Error creating download link.")
-        else:
-            logger.warning("Log content is not a list, cannot create download.")
-            st.caption("Log data unavailable for download.")
-    elif st.session_state.get('conversation_completed', False):
-         st.caption("Log content not available for download.")
+    if (
+        st.session_state.get("conversation_completed")
+        and isinstance(st.session_state.get("log_content"), list)
+        and st.session_state["log_content"]
+    ):
+        log_text = "\n".join(st.session_state["log_content"])
+        st.download_button(
+            label="Download Conversation Log",
+            data=log_text.encode("utf-8"),
+            file_name=st.session_state.get("current_log_filename", "conversation_log.txt"),
+            mime="text/plain",
+        )
+    elif st.session_state.get("conversation_completed"):
+        st.caption("Log unavailable for download.")
 
-
-# --- Optional: Logout Button ---
+# Logout
 st.sidebar.divider()
 if st.sidebar.button("Logout"):
     auth.logout()

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+# core/ — Business logic with zero Streamlit dependencies.

--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,133 @@
+# core/config.py — LLM configuration loading with zero Streamlit dependency.
+
+import os
+import json
+import logging
+from functools import lru_cache
+from typing import Optional, Tuple, Any, Dict
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "meta-llama/Meta-Llama-3.1-70B-Instruct"
+DEFAULT_TIMEOUT = 60
+DEFAULT_TEMPERATURE = 0.7
+DEFAULT_MAX_TOKENS = None
+DEFAULT_TOP_P = None
+DEFAULT_PRESENCE_PENALTY = 0.0
+DEFAULT_FREQUENCY_PENALTY = 0.0
+DEFAULT_PROMPT_DIR = "prompts"
+DEFAULT_FALLBACK_PROMPT = "You are a helpful AI assistant."
+
+
+@lru_cache(maxsize=32)
+def load_default_prompt_text(persona_name: str, mode: str) -> Optional[str]:
+    """Load the default prompt text file for a persona/mode combination."""
+    mode_suffix = mode.lower()
+    prompt_filename = f"{persona_name}_{mode_suffix}.txt"
+
+    # Try CWD first, then script-relative
+    for base in [os.getcwd(), os.path.dirname(os.path.dirname(__file__)) or '.']:
+        prompt_path = os.path.join(base, DEFAULT_PROMPT_DIR, prompt_filename)
+        if os.path.exists(prompt_path):
+            try:
+                with open(prompt_path, "r", encoding="utf-8") as f:
+                    text = f.read().strip()
+                logger.info(f"Loaded prompt for '{persona_name}' mode '{mode}' from {prompt_path}")
+                return text
+            except Exception as e:
+                logger.error(f"Error reading prompt file {prompt_path}: {e}")
+                return None
+
+    logger.error(f"Prompt file not found for '{persona_name}' mode '{mode}'")
+    return None
+
+
+@lru_cache(maxsize=16)
+def load_llm_params(persona_name: str, config_path: str = "llm_config.json") -> Dict:
+    """Load and merge LLM parameters from JSON config."""
+    try:
+        # Try CWD first, then script-relative
+        for base in [os.getcwd(), os.path.dirname(os.path.dirname(__file__)) or '.']:
+            full_path = os.path.join(base, config_path)
+            if os.path.exists(full_path):
+                with open(full_path, "r", encoding="utf-8") as f:
+                    config = json.load(f)
+                defaults = config.get("defaults", {})
+                persona_config = config.get(persona_name, {})
+                return {**defaults, **persona_config}
+        logger.error(f"Config file not found: {config_path}")
+        return {}
+    except Exception as e:
+        logger.error(f"Error loading LLM config: {e}")
+        return {}
+
+
+def load_llm_config_for_persona(
+    persona_name: str,
+    mode: str = "philosophy",
+    config_path: str = "llm_config.json",
+    prompt_overrides: Optional[Dict[str, str]] = None,
+) -> Tuple[Optional[Any], Optional[str]]:
+    """
+    Load LLM instance and effective prompt for a persona.
+
+    Returns (ChatOpenAI instance, effective_system_prompt) or (None, None).
+    """
+    load_dotenv()
+
+    api_key = os.getenv("NEBIUS_API_KEY")
+    base_url = os.getenv("NEBIUS_API_BASE")
+    if not api_key or not base_url:
+        logger.error("NEBIUS_API_KEY and NEBIUS_API_BASE must be set.")
+        return None, None
+
+    params = load_llm_params(persona_name, config_path)
+    if not params:
+        return None, None
+
+    # Load prompt
+    default_prompt = load_default_prompt_text(persona_name, mode)
+    if default_prompt is None:
+        logger.warning(f"Using fallback prompt for '{persona_name}' mode '{mode}'")
+        default_prompt = DEFAULT_FALLBACK_PROMPT
+
+    # Check overrides
+    effective_prompt = default_prompt
+    if prompt_overrides:
+        override_key = f"{persona_name}_{mode.lower()}"
+        override_text = prompt_overrides.get(override_key, "")
+        if isinstance(override_text, str) and override_text.strip():
+            effective_prompt = override_text
+            logger.info(f"Using overridden prompt for {override_key}")
+
+    # Build LLM kwargs
+    model_name = params.get("model_name", DEFAULT_MODEL)
+    llm_kwargs = {
+        "model": model_name,
+        "api_key": api_key,
+        "base_url": base_url,
+        "request_timeout": params.get("request_timeout", DEFAULT_TIMEOUT),
+        "temperature": params.get("temperature", DEFAULT_TEMPERATURE),
+    }
+    max_tokens = params.get("max_tokens", DEFAULT_MAX_TOKENS)
+    if max_tokens is not None:
+        llm_kwargs["max_tokens"] = max_tokens
+    top_p = params.get("top_p", DEFAULT_TOP_P)
+    if top_p is not None:
+        llm_kwargs["top_p"] = top_p
+    pp = params.get("presence_penalty", DEFAULT_PRESENCE_PENALTY)
+    if pp != 0.0:
+        llm_kwargs["presence_penalty"] = pp
+    fp = params.get("frequency_penalty", DEFAULT_FREQUENCY_PENALTY)
+    if fp != 0.0:
+        llm_kwargs["frequency_penalty"] = fp
+
+    try:
+        llm = ChatOpenAI(**llm_kwargs)
+        return llm, effective_prompt
+    except Exception as e:
+        logger.error(f"Error initializing ChatOpenAI for {persona_name}: {e}", exc_info=True)
+        return None, None

--- a/core/persona.py
+++ b/core/persona.py
@@ -1,0 +1,52 @@
+# core/persona.py — Single chain factory replacing socrates.py, confucius.py, moderator.py.
+
+import logging
+from typing import Optional, Any, Dict
+
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+
+from core.config import load_llm_config_for_persona
+
+logger = logging.getLogger(__name__)
+
+
+def create_chain(
+    persona_id: str,
+    mode: str = "philosophy",
+    prompt_overrides: Optional[Dict[str, str]] = None,
+) -> Optional[Any]:
+    """
+    Create a LangChain chain for any persona/mode combination.
+
+    This single factory replaces the three identical files
+    (socrates.py, confucius.py, moderator.py).
+
+    Args:
+        persona_id: Lowercase persona name (e.g. "socrates", "confucius", "moderator").
+        mode: Conversation mode (e.g. "philosophy", "bio").
+        prompt_overrides: Optional dict of override prompts keyed by "persona_mode".
+
+    Returns:
+        A LangChain chain, or None on failure.
+    """
+    logger.info(f"Creating chain for '{persona_id}' mode '{mode}'")
+    llm, system_prompt = load_llm_config_for_persona(
+        persona_id, mode=mode, prompt_overrides=prompt_overrides
+    )
+
+    if not llm or not system_prompt:
+        logger.error(f"Failed to load LLM/prompt for '{persona_id}' mode '{mode}'")
+        return None
+
+    try:
+        prompt_template = ChatPromptTemplate.from_messages([
+            ("system", system_prompt),
+            ("user", "{input}"),
+        ])
+        chain = prompt_template | llm | StrOutputParser()
+        logger.info(f"Chain created for '{persona_id}' mode '{mode}'")
+        return chain
+    except Exception as e:
+        logger.error(f"Error creating chain for '{persona_id}' mode '{mode}': {e}", exc_info=True)
+        return None

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,32 @@
+# core/utils.py — Shared utilities (think-block extraction, text cleaning).
+
+import re
+from typing import Optional, Tuple
+
+THINK_BLOCK_REGEX = re.compile(r"<think>(.*?)</think>", re.DOTALL | re.IGNORECASE)
+
+
+def extract_think_block(text: Optional[str]) -> Optional[str]:
+    """Extract content from the first <think> block found."""
+    if not text:
+        return None
+    match = THINK_BLOCK_REGEX.search(text)
+    return match.group(1).strip() if match else None
+
+
+def clean_response(text: Optional[str]) -> str:
+    """Remove all <think> blocks and return cleaned text."""
+    if not text:
+        return ""
+    return THINK_BLOCK_REGEX.sub('', text).strip()
+
+
+def extract_and_clean(raw_response: Optional[str]) -> Tuple[str, Optional[str]]:
+    """Extract think block and return (cleaned_response, monologue)."""
+    if not raw_response:
+        return "", None
+    monologue = extract_think_block(raw_response)
+    cleaned = clean_response(raw_response)
+    if not cleaned and raw_response:
+        return "", monologue
+    return cleaned, monologue

--- a/gui.py
+++ b/gui.py
@@ -1,89 +1,577 @@
-# Filename: gui.py
+# gui.py — Modern chat interface with custom HTML/CSS rendering.
 
-import streamlit as st
+import html
 import json
-import logging # Added for potential error logging
+import logging
+import streamlit as st
+from typing import List, Dict, Any, Optional
 
-# Configure logging for the GUI module
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - GUI - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Speaker visual configuration
+# ---------------------------------------------------------------------------
+SPEAKER_STYLES = {
+    "socrates": {
+        "color": "#5B8DEF",
+        "bg": "#f0f5ff",
+        "text_color": "#2D5FC4",
+        "initials": "S",
+        "display_name": "Socrates",
+    },
+    "confucius": {
+        "color": "#D4A03C",
+        "bg": "#fdf6e3",
+        "text_color": "#8B6914",
+        "initials": "C",
+        "display_name": "Confucius",
+    },
+    "moderator": {
+        "color": "#8B8B8B",
+        "bg": "#f5f5f5",
+        "text_color": "#555555",
+        "initials": "M",
+        "display_name": "Moderator",
+    },
+    "user": {
+        "color": "#2ECC71",
+        "bg": "#e8faf0",
+        "text_color": "#1B8A4A",
+        "initials": "U",
+        "display_name": "You",
+    },
+    "system": {
+        "color": "#8B8B8B",
+        "bg": "#f5f5f5",
+        "text_color": "#555555",
+        "initials": "S",
+        "display_name": "System",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# CSS Stylesheet — injected once at the top of each page render
+# ---------------------------------------------------------------------------
+CHAT_CSS = """
+<style>
+/* ===== Philosopher Dialogue Chat Styles ===== */
+
+/* Container */
+.phd-container {
+    max-width: 740px;
+    margin: 0 auto;
+    padding: 0;
+}
+
+/* App header */
+.phd-header {
+    text-align: center;
+    padding: 8px 0 20px;
+}
+.phd-title {
+    font-family: Georgia, Cambria, 'Times New Roman', serif;
+    font-size: 28px;
+    font-weight: 700;
+    color: #1a1a1a;
+    margin: 0 0 4px;
+    letter-spacing: -0.5px;
+}
+.phd-subtitle {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 14px;
+    color: #999;
+    margin: 0;
+}
+
+/* Topic Card — user's initial question */
+.phd-topic-card {
+    background: linear-gradient(135deg, #f8f9ff 0%, #fff8f0 100%);
+    border: 1px solid #e4e4e7;
+    border-radius: 14px;
+    padding: 20px 24px;
+    margin-bottom: 24px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+}
+.phd-topic-label {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: #999;
+    margin-bottom: 8px;
+    font-weight: 600;
+}
+.phd-topic-content {
+    font-family: Georgia, Cambria, 'Times New Roman', serif;
+    font-size: 17px;
+    line-height: 1.6;
+    color: #1a1a1a;
+}
+
+/* Round Separator */
+.phd-round-sep {
+    display: flex;
+    align-items: center;
+    margin: 24px 0 16px;
+    gap: 16px;
+}
+.phd-round-sep::before,
+.phd-round-sep::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: #e0e0e0;
+}
+.phd-round-text {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    color: #b0b0b0;
+    white-space: nowrap;
+    font-weight: 500;
+}
+
+/* Message Turn */
+.phd-turn {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 6px 0;
+    margin: 6px 0;
+}
+
+/* Avatar */
+.phd-avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-weight: 700;
+    font-size: 14px;
+    color: white;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+}
+
+/* Message Body */
+.phd-msg-body {
+    flex: 1;
+    min-width: 0;
+}
+.phd-msg-header {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 3px;
+}
+.phd-speaker {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-weight: 600;
+    font-size: 14px;
+}
+.phd-meta {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 11px;
+    color: #b0b0b0;
+}
+
+/* Message Card */
+.phd-card {
+    padding: 12px 16px;
+    border-radius: 10px;
+    border-left: 3px solid transparent;
+}
+.phd-content {
+    font-family: Georgia, Cambria, 'Times New Roman', serif;
+    font-size: 16px;
+    line-height: 1.75;
+    color: #1a1a1a;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+.phd-content p {
+    margin: 0 0 8px;
+}
+.phd-content p:last-child {
+    margin-bottom: 0;
+}
+
+/* Moderator Context (collapsible) */
+.phd-mod-ctx {
+    margin: 4px 0 4px 48px;
+    border-radius: 6px;
+}
+.phd-mod-toggle {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 12px;
+    color: #aaa;
+    cursor: pointer;
+    padding: 5px 10px;
+    border-radius: 6px;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    user-select: none;
+}
+.phd-mod-toggle::-webkit-details-marker { display: none; }
+.phd-mod-toggle:hover {
+    background: rgba(0,0,0,0.03);
+    color: #777;
+}
+.phd-mod-body {
+    padding: 8px 12px 10px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 13px;
+    line-height: 1.5;
+    color: #666;
+    background: #f7f7f7;
+    border-radius: 0 0 6px 6px;
+}
+.phd-mod-body strong {
+    color: #555;
+}
+
+/* User Guidance */
+.phd-guidance {
+    margin: 4px 0 8px 48px;
+    padding: 8px 14px;
+    border-radius: 8px;
+    border-left: 3px solid #2ECC71;
+    background: #eafaf1;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 13px;
+    color: #1B8A4A;
+    line-height: 1.5;
+}
+.phd-guidance-label {
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: #27ae60;
+    margin-bottom: 2px;
+}
+
+/* Error message */
+.phd-error {
+    margin: 4px 0 8px 48px;
+    padding: 8px 14px;
+    border-radius: 8px;
+    border-left: 3px solid #e74c3c;
+    background: #fdf0ef;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 13px;
+    color: #c0392b;
+}
+
+/* Empty State */
+.phd-empty {
+    text-align: center;
+    padding: 60px 20px;
+}
+.phd-empty-icon {
+    font-size: 48px;
+    margin-bottom: 16px;
+    opacity: 0.4;
+}
+.phd-empty-text {
+    font-family: Georgia, Cambria, serif;
+    font-size: 18px;
+    color: #888;
+    margin-bottom: 8px;
+}
+.phd-empty-hint {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 14px;
+    color: #bbb;
+}
+
+/* Completion Banner */
+.phd-complete {
+    text-align: center;
+    padding: 14px 20px;
+    margin: 20px 0 8px;
+    border-radius: 10px;
+    background: linear-gradient(135deg, #f0f5ff 0%, #fdf6e3 100%);
+    border: 1px solid #e4e4e7;
+}
+.phd-complete-text {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 13px;
+    color: #777;
+}
+
+/* Waiting indicator */
+.phd-waiting {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    margin: 12px 0 4px 48px;
+    border-radius: 10px;
+    border-left: 3px solid #2ECC71;
+    background: #eafaf1;
+}
+.phd-waiting-label {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 13px;
+    font-style: italic;
+    color: #27ae60;
+}
+.phd-dots {
+    display: inline-flex;
+    gap: 3px;
+}
+.phd-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: #27ae60;
+    animation: phd-pulse 1.4s infinite ease-in-out both;
+}
+.phd-dot:nth-child(1) { animation-delay: -0.32s; }
+.phd-dot:nth-child(2) { animation-delay: -0.16s; }
+.phd-dot:nth-child(3) { animation-delay: 0s; }
+@keyframes phd-pulse {
+    0%, 80%, 100% { transform: scale(0.6); opacity: 0.4; }
+    40% { transform: scale(1); opacity: 1; }
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .phd-turn { gap: 8px; }
+    .phd-avatar { width: 30px; height: 30px; font-size: 12px; }
+    .phd-content { font-size: 15px; line-height: 1.6; }
+    .phd-topic-card { padding: 16px; }
+    .phd-mod-ctx, .phd-guidance, .phd-error, .phd-waiting { margin-left: 38px; }
+}
+@media (max-width: 480px) {
+    .phd-avatar { width: 26px; height: 26px; font-size: 11px; }
+    .phd-content { font-size: 14px; }
+    .phd-card { padding: 10px 12px; }
+    .phd-mod-ctx, .phd-guidance, .phd-error, .phd-waiting { margin-left: 34px; }
+}
+
+/* Override Streamlit defaults for cleaner look */
+div[data-testid="stChatInput"] textarea::placeholder {
+    font-style: italic;
+}
+</style>
+"""
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering helpers
+# ---------------------------------------------------------------------------
+
+def _esc(text: str) -> str:
+    """HTML-escape text, preserving newlines as <br>."""
+    escaped = html.escape(str(text))
+    return escaped.replace("\n", "<br>")
+
+
+def _get_style(role: str) -> dict:
+    """Get the visual style dict for a given role."""
+    key = role.lower().strip()
+    return SPEAKER_STYLES.get(key, SPEAKER_STYLES["system"])
+
+
+def _render_topic_card(content: str) -> str:
+    """Render the user's initial question as a topic card."""
+    return (
+        '<div class="phd-topic-card">'
+        '<div class="phd-topic-label">Topic for Discussion</div>'
+        f'<div class="phd-topic-content">{_esc(content)}</div>'
+        '</div>'
+    )
+
+
+def _render_round_separator(round_num: int) -> str:
+    """Render a round divider line."""
+    return (
+        '<div class="phd-round-sep">'
+        f'<span class="phd-round-text">Round {round_num}</span>'
+        '</div>'
+    )
+
+
+def _render_message(role: str, content: str, round_num: int = 0) -> str:
+    """Render a philosopher or user message as a chat turn."""
+    style = _get_style(role)
+    meta = f"Round {round_num}" if round_num > 0 else ""
+    return (
+        f'<div class="phd-turn">'
+        f'  <div class="phd-avatar" style="background:{style["color"]};">{style["initials"]}</div>'
+        f'  <div class="phd-msg-body">'
+        f'    <div class="phd-msg-header">'
+        f'      <span class="phd-speaker" style="color:{style["text_color"]};">{style["display_name"]}</span>'
+        f'      <span class="phd-meta">{meta}</span>'
+        f'    </div>'
+        f'    <div class="phd-card" style="border-left-color:{style["color"]}; background:{style["bg"]};">'
+        f'      <div class="phd-content">{_esc(content)}</div>'
+        f'    </div>'
+        f'  </div>'
+        f'</div>'
+    )
+
+
+def _render_moderator_context(content: str) -> str:
+    """Render moderator context as a collapsible details element."""
+    # Parse SUMMARY and GUIDANCE from the content
+    lines = content.strip().splitlines()
+    summary = ""
+    guidance = ""
+    target = ""
+
+    for line in lines:
+        stripped = line.strip()
+        upper = stripped.upper()
+        if upper.startswith("MODERATOR CONTEXT"):
+            # Extract target from "MODERATOR CONTEXT (for Confucius):"
+            if "(" in stripped and ")" in stripped:
+                target = stripped[stripped.index("(") + 1:stripped.index(")")]
+        elif upper.startswith("SUMMARY:"):
+            summary = stripped.split(":", 1)[1].strip() if ":" in stripped else ""
+        elif upper.startswith("AI GUIDANCE:") or upper.startswith("GUIDANCE:"):
+            guidance = stripped.split(":", 1)[1].strip() if ":" in stripped else ""
+
+    target_text = f" for {_esc(target)}" if target else ""
+    body_parts = []
+    if summary:
+        body_parts.append(f'<strong>Summary:</strong> {_esc(summary)}')
+    if guidance:
+        body_parts.append(f'<strong>Guidance:</strong> {_esc(guidance)}')
+    if not body_parts:
+        body_parts.append(_esc(content))
+
+    body_html = "<br>".join(body_parts)
+
+    return (
+        f'<details class="phd-mod-ctx">'
+        f'  <summary class="phd-mod-toggle">&#9881; Moderator Context{_esc(target_text)}</summary>'
+        f'  <div class="phd-mod-body">{body_html}</div>'
+        f'</details>'
+    )
+
+
+def _render_user_guidance(content: str) -> str:
+    """Render user guidance message."""
+    # Strip the "USER GUIDANCE FOR <name>:" prefix if present
+    display = content
+    if ":" in content and content.strip().upper().startswith("USER GUIDANCE"):
+        display = content.split(":", 1)[1].strip()
+    elif content.strip().upper().startswith("SYSTEM:"):
+        display = content.split(":", 1)[1].strip()
+
+    return (
+        f'<div class="phd-guidance">'
+        f'  <div class="phd-guidance-label">Your Guidance</div>'
+        f'  {_esc(display)}'
+        f'</div>'
+    )
+
+
+def _render_error(content: str) -> str:
+    """Render an error message."""
+    return f'<div class="phd-error">{_esc(content)}</div>'
+
+
+def _render_empty_state() -> str:
+    """Render the empty conversation state."""
+    return (
+        '<div class="phd-empty">'
+        '  <div class="phd-empty-icon">&#x1F4AC;</div>'
+        '  <div class="phd-empty-text">Begin a philosophical dialogue</div>'
+        '  <div class="phd-empty-hint">Enter a question below to start the conversation between Socrates and Confucius</div>'
+        '</div>'
+    )
+
+
+def _render_completion_banner(mode: str, num_rounds: int) -> str:
+    """Render the conversation completion banner."""
+    return (
+        '<div class="phd-complete">'
+        f'  <div class="phd-complete-text">Dialogue complete &mdash; {num_rounds} round{"s" if num_rounds != 1 else ""} in {_esc(mode)} mode</div>'
+        '</div>'
+    )
+
+
+def _render_waiting_indicator(next_speaker: str) -> str:
+    """Render the waiting-for-guidance indicator."""
+    return (
+        '<div class="phd-waiting">'
+        f'  <span class="phd-waiting-label">Awaiting your guidance for {_esc(next_speaker)}</span>'
+        '  <span class="phd-dots">'
+        '    <span class="phd-dot"></span>'
+        '    <span class="phd-dot"></span>'
+        '    <span class="phd-dot"></span>'
+        '  </span>'
+        '</div>'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def inject_chat_css():
+    """Inject the chat stylesheet into the page. Call once at page top."""
+    st.markdown(CHAT_CSS, unsafe_allow_html=True)
+
 
 def display_header():
-    """Displays the main title of the application."""
-    st.title("Philosopher Dialogue (Streamlit Edition)")
+    """Render the application header."""
+    st.markdown(
+        '<div class="phd-header">'
+        '  <h1 class="phd-title">Philosopher Dialogue</h1>'
+        '  <p class="phd-subtitle">A moderated conversation between Socrates and Confucius</p>'
+        '</div>',
+        unsafe_allow_html=True,
+    )
 
-def get_model_info_from_config(config_path="llm_config.json"):
-    """Loads model names from config file for display."""
+
+def get_model_info_from_config(config_path: str = "llm_config.json") -> Dict[str, str]:
+    """Load model names from config for sidebar display."""
     try:
         with open(config_path, "r", encoding="utf-8") as f:
             config = json.load(f)
-        # Provide default 'Unknown' if a persona or model_name is missing
-        # Note: Model names are still useful even if prompts are dynamic
         return {
-            'Socrates': config.get('socrates', {}).get('model_name', 'Unknown'),
-            'Confucius': config.get('confucius', {}).get('model_name', 'Unknown'),
-            'Moderator': config.get('moderator', {}).get('model_name', 'Unknown'),
+            "Socrates": config.get("socrates", {}).get("model_name", "Unknown"),
+            "Confucius": config.get("confucius", {}).get("model_name", "Unknown"),
+            "Moderator": config.get("moderator", {}).get("model_name", "Unknown"),
         }
-    except FileNotFoundError:
-        warning_msg = f"Config file not found at {config_path}. Cannot display model info."
-        st.warning(warning_msg)
-        logging.warning(warning_msg)
-        return {'Socrates': 'Unknown', 'Confucius': 'Unknown', 'Moderator': 'Unknown'}
-    except json.JSONDecodeError as e:
-        error_msg = f"Error decoding JSON from {config_path}: {e}"
-        st.error(error_msg)
-        logging.error(error_msg)
-        return {'Socrates': 'Unknown', 'Confucius': 'Unknown', 'Moderator': 'Unknown'}
     except Exception as e:
-        error_msg = f"Error loading model info from config {config_path}: {e}"
-        st.error(error_msg)
-        logging.error(error_msg, exc_info=True) # Log full traceback
-        return {'Socrates': 'Unknown', 'Confucius': 'Unknown', 'Moderator': 'Unknown'}
+        logger.warning(f"Could not load model info: {e}")
+        return {"Socrates": "Unknown", "Confucius": "Unknown", "Moderator": "Unknown"}
 
 
-def display_sidebar(model_info):
-    """Displays information and controls in the sidebar."""
+def display_sidebar(model_info: Dict[str, str]):
+    """Render the sidebar configuration panel."""
     with st.sidebar:
         st.header("Configuration")
 
-        # --- Mode Selection ---
+        # --- Conversation Setup ---
         st.radio(
             "Conversation Mode:",
-            # Use lowercase, underscore for keys used in filenames
-            options=['Philosophy', 'Bio'],
-            # Map display names to internal keys
-            format_func=lambda x: "Philosophical Mode" if x == 'Philosophy' else "Biographical Mode",
-            key='conversation_mode', # Unique key for session state
-            index=0, # Default to Philosophical
+            options=["Philosophy", "Bio"],
+            format_func=lambda x: "Philosophical" if x == "Philosophy" else "Biographical",
+            key="conversation_mode",
+            index=0,
             horizontal=True,
-            help="Select the conversation topic focus."
+            help="Select the conversation topic focus.",
         )
-        st.divider()
-
-        # --- Moderator Control Mode ---
-        st.radio(
-            "Moderator Control:",
-            options=['AI Moderator', 'User as Moderator (Guidance)'],
-            format_func=lambda x: x, # Display names are fine
-            key='moderator_control_mode',
-            index=0, # Default to AI Moderator
-            horizontal=True,
-            help="Choose who provides guidance: AI or User. AI always provides summary."
-        )
-        # --- End Moderator Control Mode ---
-
-        st.caption("Model Instances:")
-        st.markdown(f"**Socrates:** `{model_info.get('Socrates', 'Unknown')}`")
-        st.markdown(f"**Confucius:** `{model_info.get('Confucius', 'Unknown')}`")
-        st.markdown(f"**Moderator:** `{model_info.get('Moderator', 'Unknown')}`")
-
-        st.divider()
 
         st.radio(
             "Starting Philosopher:",
-            ('Socrates', 'Confucius'),
-            key='starting_philosopher',
+            ("Socrates", "Confucius"),
+            key="starting_philosopher",
             horizontal=True,
-            index=0 # Default to Socrates
+            index=0,
         )
 
         st.number_input(
@@ -91,91 +579,193 @@ def display_sidebar(model_info):
             min_value=1,
             max_value=10,
             step=1,
-            key='num_rounds',
-            help="One round includes one response from each philosopher."
+            key="num_rounds",
+            help="One round = one response from each philosopher.",
         )
 
         st.divider()
 
+        # --- Moderation ---
         st.radio(
-            "Output Style:",
-            ('Original Text', 'Translated Text'),
-            key='output_style',
+            "Moderator Control:",
+            options=["AI Moderator", "User as Moderator (Guidance)"],
+            key="moderator_control_mode",
+            index=0,
             horizontal=True,
-            index=0, # Default to Original
-            help="Choose to view the original dialogue or a more casual translation (applied after conversation finishes)."
+            help="Choose who provides guidance: AI or You. AI always provides summary.",
         )
-        
-        st.caption("Display Options:")
 
         st.checkbox(
-            "Bypass Moderator (Direct Dialogue)",
-            key='bypass_moderator_cb',
-            value=st.session_state.get('bypass_moderator_cb', False),
-            help="If checked, philosophers respond directly without moderator summaries/guidance. Overrides 'Moderator Control' selection."
+            "Bypass Moderator",
+            key="bypass_moderator_cb",
+            value=st.session_state.get("bypass_moderator_cb", False),
+            help="Philosophers respond directly without moderator.",
+        )
+
+        st.divider()
+
+        # --- Display ---
+        st.radio(
+            "Output Style:",
+            ("Original Text", "Translated Text"),
+            key="output_style",
+            horizontal=True,
+            index=0,
+            help="View original dialogue or a casual translation (applied after completion).",
         )
 
         st.checkbox(
             "Show Moderator Context",
-            key='show_moderator_cb',
-            value=st.session_state.get('show_moderator_cb', False),
-            help="Show/hide the Moderator's SUMMARY/GUIDANCE blocks in the chat."
+            key="show_moderator_cb",
+            value=st.session_state.get("show_moderator_cb", False),
+            help="Show/hide the moderator's summary and guidance blocks.",
         )
 
         st.checkbox(
             "Show Internal Monologue",
-            key='show_monologue_cb',
-            value=st.session_state.get('show_monologue_cb', False),
-            help="Show/hide the <think> blocks extracted from LLM responses."
+            key="show_monologue_cb",
+            value=st.session_state.get("show_monologue_cb", False),
+            help="Show/hide the LLM's <think> blocks.",
         )
 
+        st.divider()
 
-def display_conversation(messages):
-    """Displays the chat messages, conditionally hiding moderator context."""
-    show_moderator_ctx = st.session_state.get('show_moderator_cb', True)
-    moderator_control_mode = st.session_state.get('moderator_control_mode', 'AI Moderator')
-    awaiting_user_guidance = st.session_state.get('awaiting_user_guidance', False)
+        # --- Model Info (compact) ---
+        with st.expander("Model Info", expanded=False):
+            st.markdown(f"**Socrates:** `{model_info.get('Socrates', 'Unknown')}`")
+            st.markdown(f"**Confucius:** `{model_info.get('Confucius', 'Unknown')}`")
+            st.markdown(f"**Moderator:** `{model_info.get('Moderator', 'Unknown')}`")
+
+
+def display_conversation(
+    messages: List[Dict[str, Any]],
+    show_moderator_ctx: Optional[bool] = None,
+    conversation_completed: bool = False,
+    awaiting_guidance: bool = False,
+    next_speaker_for_guidance: str = "",
+    num_rounds: int = 0,
+    mode: str = "",
+):
+    """
+    Render the full conversation using custom HTML.
+
+    This replaces the old st.chat_message approach with a modern
+    turn-by-turn chat interface featuring:
+    - Color-coded speakers with avatar circles
+    - Left-border accent on message cards
+    - Round separators
+    - Collapsible moderator context
+    - Serif typography for dialogue
+    """
+    if show_moderator_ctx is None:
+        show_moderator_ctx = st.session_state.get("show_moderator_cb", False)
 
     if not messages:
-        st.info("Start the conversation by entering a question below.")
+        st.markdown(_render_empty_state(), unsafe_allow_html=True)
         return
 
-    for message in messages:
-        role = message.get("role", "system")
-        content = message.get('content', '')
+    html_parts = ['<div class="phd-container">']
+    philosopher_turn_count = 0
+    current_round = 0
 
-        is_moderator_system_message = (role.lower() == 'system' and
-                                      isinstance(content, str) and
-                                      (content.strip().startswith("MODERATOR CONTEXT") or
-                                       content.strip().startswith("USER GUIDANCE FOR")))
+    for msg in messages:
+        role = msg.get("role", "system")
+        content = msg.get("content", "")
+        role_lower = role.lower().strip()
 
-
-        if is_moderator_system_message and not show_moderator_ctx:
-            # If user has "Show Moderator Context" unchecked, hide all moderator-related system messages
+        # --- User message → topic card ---
+        if role_lower == "user":
+            html_parts.append(_render_topic_card(content))
             continue
-        
-        if (is_moderator_system_message and
-            content.strip().startswith("MODERATOR CONTEXT") and
-            moderator_control_mode == 'User as Moderator (Guidance)' and
-            not awaiting_user_guidance and
-            "AI Guidance:" in content):
-            pass
+
+        # --- Philosopher messages ---
+        if role_lower in ("socrates", "confucius"):
+            philosopher_turn_count += 1
+            round_num = (philosopher_turn_count - 1) // 2 + 1
+
+            # Insert round separator at the start of each new round
+            if round_num != current_round:
+                current_round = round_num
+                html_parts.append(_render_round_separator(round_num))
+
+            html_parts.append(_render_message(role, content, round_num))
+            continue
+
+        # --- System messages (moderator context, guidance, errors, translation) ---
+        if role_lower == "system":
+            content_str = str(content).strip() if content else ""
+            content_upper = content_str.upper()
+
+            # Moderator context
+            if content_upper.startswith("MODERATOR CONTEXT"):
+                if show_moderator_ctx:
+                    html_parts.append(_render_moderator_context(content_str))
+                continue
+
+            # User guidance
+            if content_upper.startswith("USER GUIDANCE FOR") or content_upper.startswith("SYSTEM: USER OPTED"):
+                if show_moderator_ctx:
+                    html_parts.append(_render_user_guidance(content_str))
+                continue
+
+            # Error messages
+            if content_upper.startswith("ERROR:"):
+                html_parts.append(_render_error(content_str))
+                continue
+
+            # Translated conversation or other system messages
+            if content_str:
+                # For translated text or general system messages,
+                # render as a simple card
+                html_parts.append(
+                    f'<div style="padding:12px 16px; margin:8px 0; '
+                    f'border-radius:10px; background:#fafafa; '
+                    f'font-family:Georgia,Cambria,serif; font-size:16px; '
+                    f'line-height:1.75; color:#1a1a1a;">'
+                    f'{_esc(content_str)}</div>'
+                )
+            continue
+
+        # --- Fallback: unknown role (treat as philosopher-like) ---
+        html_parts.append(_render_message(role, content))
+
+    # --- Waiting indicator ---
+    if awaiting_guidance and next_speaker_for_guidance:
+        html_parts.append(_render_waiting_indicator(next_speaker_for_guidance))
+
+    # --- Completion banner ---
+    if conversation_completed and not awaiting_guidance:
+        html_parts.append(
+            _render_completion_banner(mode or "Philosophy", num_rounds or current_round)
+        )
+
+    html_parts.append('</div>')
+
+    st.markdown("\n".join(html_parts), unsafe_allow_html=True)
 
 
-        display_role = "user" if role.lower() == "user" else "assistant"
-        avatar = "👤" if display_role=="user" else "🤖"
-        if role.lower() == "system" and "guidance" in content.lower():
-             avatar = "🧑‍🏫"
-        elif role.lower() not in ["user", "system"]:
-             avatar = "🧑‍🎨"
+def display_monologue(messages: List[Dict[str, Any]]):
+    """Render internal monologue/thinking in an expander if enabled."""
+    if not st.session_state.get("show_monologue_cb", False):
+        return
 
+    monologue_entries = []
+    for msg in messages:
+        if isinstance(msg, dict):
+            monologue = msg.get("monologue")
+            role = msg.get("role", "Unknown")
+            if monologue:
+                monologue_entries.append((role, monologue))
 
-        with st.chat_message(display_role, avatar=avatar):
-             prefix = ""
-             if display_role == "assistant" and role.lower() not in ['system', 'user']:
-                 prefix = f"**{role}:**\n"
-             elif role.lower() == 'system' and (content.strip().startswith("MODERATOR CONTEXT") or content.strip().startswith("USER GUIDANCE FOR")):
-                 pass
-             
-             display_content = str(content) if content is not None else ""
-             st.markdown(f"{prefix}{display_content}")
+    if not monologue_entries:
+        return
+
+    with st.expander("Internal Monologue / Thinking", expanded=False):
+        for role, text in monologue_entries:
+            style = _get_style(role)
+            st.markdown(
+                f'**<span style="color:{style["text_color"]};">[{style["display_name"]}] Thinking:</span>**',
+                unsafe_allow_html=True,
+            )
+            st.text(str(text))
+            st.divider()

--- a/llm_config.json
+++ b/llm_config.json
@@ -11,7 +11,7 @@
   "socrates": {
     "model_name": "Qwen/Qwen3-235B-A22B",
     "temperature": 0.5,
-    "max_tokens": 100,
+    "max_tokens": 250,
     "top_p": 0.95,
     "presence_penalty": 0.1,
     "frequency_penalty": 0.1,
@@ -20,7 +20,7 @@
   "confucius": {
     "model_name": "Qwen/Qwen3-235B-A22B",
     "temperature": 0.6,
-    "max_tokens": 110,
+    "max_tokens": 250,
     "top_p": 0.9,
     "presence_penalty": 0.0,
     "frequency_penalty": 0.0,
@@ -29,7 +29,7 @@
   "moderator": {
     "model_name": "meta-llama/Meta-Llama-3.1-70B-Instruct",
     "temperature": 0.6,
-    "max_tokens": 50,
+    "max_tokens": 200,
     "top_p": 0.85,
     "request_timeout": 30
   },

--- a/llm_loader.py
+++ b/llm_loader.py
@@ -1,196 +1,34 @@
-# Filename: llm_loader.py
+# llm_loader.py — Backward-compatible wrapper around core.config.
+#
+# The pages (Direct Chat, Settings) import from here. This thin wrapper
+# delegates to core.config while still supporting Streamlit session-state
+# prompt overrides that the pages rely on.
 
-import os
-import json
 import logging
-from dotenv import load_dotenv
-from langchain_openai import ChatOpenAI
-import streamlit as st # Import streamlit to access session state
+import streamlit as st
 
-# Configure logging for the loader module
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - LOADER - %(levelname)s - %(message)s')
+from core.config import (
+    load_default_prompt_text as _core_load_default_prompt_text,
+    load_llm_config_for_persona as _core_load_llm_config_for_persona,
+)
+
 logger = logging.getLogger(__name__)
 
-# Default values
-DEFAULT_MODEL = "meta-llama/Meta-Llama-3.1-70B-Instruct"
-DEFAULT_TIMEOUT = 60
-DEFAULT_TEMPERATURE = 0.7
-DEFAULT_MAX_TOKENS = None
-DEFAULT_TOP_P = None
-DEFAULT_PRESENCE_PENALTY = 0.0
-DEFAULT_FREQUENCY_PENALTY = 0.0
-DEFAULT_PROMPT_DIR = "prompts"
-DEFAULT_FALLBACK_PROMPT = "You are a helpful AI assistant." # Fallback if specific prompt file is missing
 
-# --- Function to load ONLY the default prompt text ---
-# Use Streamlit caching for default prompt text
-@st.cache_data(ttl=3600) # Cache for 1 hour
-def load_default_prompt_text(persona_name: str, mode: str) -> str | None:
+def load_default_prompt_text(persona_name: str, mode: str):
+    """Load default prompt text (delegates to core.config)."""
+    return _core_load_default_prompt_text(persona_name, mode)
+
+
+def load_llm_config_for_persona(persona_name: str, mode: str = "philosophy", config_path: str = "llm_config.json"):
     """
-    Loads and returns the text content of the default prompt file for a given
-    persona and mode. Returns None if the file cannot be read. Caches result.
+    Load LLM config with session-state prompt override support.
+
+    This wrapper reads prompt_overrides from st.session_state so that the
+    Settings page can inject custom prompts that take effect immediately.
     """
-    logger.info(f"Attempting to load default prompt text for '{persona_name}' mode '{mode}'")
-    # Construct prompt filename dynamically
-    mode_suffix = mode.lower()
-    prompt_filename = f"{persona_name}_{mode_suffix}.txt"
-    # Assume prompts are in a 'prompts' subdirectory relative to this script's dir
-    # Adjust if your prompts dir is elsewhere relative to where app is run
-    try:
-        # Try finding prompts relative to current working directory first
-        cwd = os.getcwd()
-        prompt_dir_path = os.path.join(cwd, DEFAULT_PROMPT_DIR)
-        prompt_path = os.path.join(prompt_dir_path, prompt_filename)
-        logger.debug(f"Checking for prompt at: {prompt_path}")
-        if not os.path.exists(prompt_path):
-             # Fallback: Try finding prompts relative to the script's directory
-             script_dir = os.path.dirname(__file__) or '.'
-             prompt_dir_path = os.path.join(script_dir, DEFAULT_PROMPT_DIR)
-             prompt_path = os.path.join(prompt_dir_path, prompt_filename)
-             logger.debug(f"Checking for prompt at fallback path: {prompt_path}")
-
-
-        with open(prompt_path, "r", encoding="utf-8") as pf:
-            system_prompt = pf.read().strip()
-        logger.info(f"Successfully loaded default prompt text for '{persona_name}' mode '{mode}' from {prompt_path}")
-        return system_prompt
-    except FileNotFoundError:
-        logger.error(f"Default prompt file not found for persona '{persona_name}' mode '{mode}' at expected paths.")
-        return None
-    except Exception as e:
-        logger.error(f"Error reading default prompt file {prompt_path}: {e}.")
-        return None
-
-# --- Modified function to load LLM config AND check for prompt overrides ---
-# Consider caching the LLM instance + config loading part
-# Use cache_resource for non-hashable objects like LLM clients
-# Key needs to include things that change the LLM object: persona_name, model params, API key info indirectly
-# Caching LLM might be complex if parameters change frequently or per-persona significantly.
-# For now, let's focus on caching prompts and config read.
-
-@st.cache_data(ttl=3600)
-def _load_llm_params(persona_name: str, config_path="llm_config.json") -> dict:
-    """Loads and caches parameters from JSON config."""
-    logger.info(f"Loading LLM params for {persona_name} from {config_path}")
-    try:
-        with open(config_path, "r", encoding="utf-8") as f: config = json.load(f)
-    except Exception as e:
-        logger.error(f"Error loading/parsing LLM config {config_path}: {e}")
-        return {} # Return empty dict on failure
-
-    persona_config = config.get(persona_name, {})
-    defaults = config.get("defaults", {})
-    merged = {**defaults, **persona_config}
-    return merged
-
-def load_llm_config_for_persona(persona_name: str, mode: str = 'philosophy', config_path="llm_config.json"):
-    """
-    Loads LLM config, loads the DEFAULT system prompt text, checks session state
-    for an OVERRIDDEN prompt, and returns the LLM instance and the
-    effective (default or overridden) system prompt text.
-
-    Args:
-        persona_name (str): The name of the persona section (e.g., "socrates").
-        mode (str): The conversation mode (e.g., "philosophy", "bio").
-        config_path (str): Path to the JSON configuration file.
-
-    Returns:
-        tuple: (ChatOpenAI instance or None, effective_system_prompt string or None)
-    """
-    # load_dotenv() # Called once in app.py now
-
-    api_key = os.getenv("NEBIUS_API_KEY")
-    base_url = os.getenv("NEBIUS_API_BASE")
-
-    if not api_key or not base_url:
-        logger.error("NEBIUS_API_KEY and NEBIUS_API_BASE must be set.")
-        return None, None
-
-    # --- Load LLM Parameters using cached function ---
-    merged_params = _load_llm_params(persona_name, config_path)
-    if not merged_params: # Handle failure in loading params
-        return None, None
-
-    # --- Load DEFAULT System Prompt Text (uses caching internally) ---
-    default_system_prompt = load_default_prompt_text(persona_name, mode)
-    if default_system_prompt is None:
-        logger.warning(f"Using fallback prompt for '{persona_name}' mode '{mode}' due to missing/unreadable default file.")
-        default_system_prompt = DEFAULT_FALLBACK_PROMPT
-
-    # --- Check for User Override in Session State ---
-    effective_system_prompt = default_system_prompt # Start with the default
-    override_key = f"{persona_name}_{mode.lower()}"
-    # Initialize prompt_overrides in session state if it doesn't exist
-    # setdefault needed here in case Settings page hasn't run yet
-    st.session_state.setdefault('prompt_overrides', {})
-
-    if override_key in st.session_state.prompt_overrides:
-        # Ensure override is not empty string, otherwise use default
-        override_text = st.session_state.prompt_overrides[override_key]
-        if isinstance(override_text, str) and override_text.strip():
-            effective_system_prompt = override_text
-            logger.info(f"Using OVERRIDDEN prompt for {override_key}")
-        else:
-            logger.info(f"Ignoring empty override, using DEFAULT prompt for {override_key}")
-            effective_system_prompt = default_system_prompt # Fallback to default if override is empty
-    else:
-        logger.info(f"Using DEFAULT prompt for {override_key}")
-
-
-    # --- Determine Final LLM Parameters ---
-    final_params = merged_params # Use loaded params
-    model_name = final_params.get("model_name", DEFAULT_MODEL)
-    temperature = final_params.get("temperature", DEFAULT_TEMPERATURE)
-    max_tokens = final_params.get("max_tokens", DEFAULT_MAX_TOKENS)
-    top_p = final_params.get("top_p", DEFAULT_TOP_P)
-    presence_penalty = final_params.get("presence_penalty", DEFAULT_PRESENCE_PENALTY)
-    frequency_penalty = final_params.get("frequency_penalty", DEFAULT_FREQUENCY_PENALTY)
-    request_timeout = final_params.get("request_timeout", DEFAULT_TIMEOUT)
-
-    # --- Prepare LLM Arguments ---
-    llm_kwargs = {
-        "model": model_name, "api_key": api_key, "base_url": base_url,
-        "request_timeout": request_timeout, "temperature": temperature,
-    }
-    # Only add parameters if they are not None, to allow API defaults if preferred
-    if max_tokens is not None: llm_kwargs["max_tokens"] = max_tokens
-    if top_p is not None: llm_kwargs["top_p"] = top_p
-    # Penalties usually default to 0.0, only add if explicitly non-zero
-    if presence_penalty != 0.0: llm_kwargs["presence_penalty"] = presence_penalty
-    if frequency_penalty != 0.0: llm_kwargs["frequency_penalty"] = frequency_penalty
-
-    logger.info(f"LLM '{persona_name}' (mode: {mode}): Model='{model_name}', Temp={temperature}, MaxTokens={max_tokens}, Timeout={request_timeout}")
-
-    # --- Initialize LLM ---
-    # TODO: Consider caching the LLM instance if beneficial (using st.cache_resource)
-    # Cache key would need to combine relevant parts of llm_kwargs
-    try:
-        llm = ChatOpenAI(**llm_kwargs)
-        # Return LLM and the effective prompt (default or overridden)
-        return llm, effective_system_prompt
-    except Exception as e:
-        logger.error(f"Error initializing ChatOpenAI for {persona_name}: {e}", exc_info=True)
-        logger.error("Check API key, base URL, model name, and parameters.")
-        return None, None
-
-# --- Example Usage ---
-# (Keep __main__ block unchanged if needed for testing)
-if __name__ == "__main__":
-     # This block won't have Streamlit context (caching, session_state)
-     # It will test basic loading logic without overrides/caching active
-     print("Testing LLM Loader (without Streamlit session state)...")
-     # Test loading default mode (philosophy)
-     s_llm_p, s_prompt_p = load_llm_config_for_persona("socrates", mode='philosophy')
-     if s_llm_p: print(f"\nSocrates (Philosophy) LLM OK.")
-     else: print("\nSocrates (Philosophy) LLM failed.")
-     print(f"Prompt loaded: '{s_prompt_p[:80]}...'")
-
-     # Test loading default text directly
-     print("\nTesting direct default prompt loading...")
-     default_s_bio = load_default_prompt_text("socrates", "bio")
-     if default_s_bio: print(f"Default Socrates Bio prompt fetched: '{default_s_bio[:80]}...'")
-     else: print("Fetching default Socrates Bio prompt FAILED.")
-
-     default_m_phil = load_default_prompt_text("moderator", "philosophy")
-     if default_m_phil: print(f"Default Moderator Phil prompt fetched: '{default_m_phil[:80]}...'")
-     else: print("Fetching default Moderator Phil prompt FAILED.")
+    st.session_state.setdefault("prompt_overrides", {})
+    overrides = dict(st.session_state.prompt_overrides)
+    return _core_load_llm_config_for_persona(
+        persona_name, mode=mode, config_path=config_path, prompt_overrides=overrides
+    )

--- a/pages/1_🤖_Direct_Chat.py
+++ b/pages/1_🤖_Direct_Chat.py
@@ -1,304 +1,275 @@
-# pages/1_🤖_Direct_Chat.py
+# pages/1_Direct_Chat.py — Debug page for chatting with individual personas.
+
+import os
+import sys
+import logging
 
 import streamlit as st
-import os
-import logging
-import re # Import regex module
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.output_parsers import StrOutputParser
-# Import message types required for history conversion
 from langchain_core.messages import AIMessage, HumanMessage, BaseMessage
-from typing import List # Import List for type hinting
+from typing import List
 
-# --- Authentication Import and Check ---
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
 try:
-    import auth # Import the new authentication module
+    import auth
 except ImportError:
-    st.error("Fatal Error: Authentication module (`auth.py`) not found.")
+    st.error("Fatal: `auth.py` not found.")
     st.stop()
 
-# Check authentication status using the auth module
-# Initialize session state variable if it doesn't exist
 if "authenticated" not in st.session_state:
     st.session_state.authenticated = False
-# Run check - stops if not authenticated
 if not auth.check_password():
     st.stop()
-# --- End Authentication Check ---
 
-
-# Assuming llm_loader.py is in the parent directory or accessible via PYTHONPATH
-import sys
-# Ensure the parent directory is in the path only once if needed
+# ---------------------------------------------------------------------------
+# Imports (ensure parent directory is on path for llm_loader)
+# ---------------------------------------------------------------------------
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
+    sys.path.insert(0, parent_dir)
+
 try:
     from llm_loader import load_llm_config_for_persona
-except ImportError:
-    st.error("Could not import `llm_loader`. Make sure it's accessible.")
+    from core.utils import extract_think_block, clean_response
+    import gui
+except ImportError as e:
+    st.error(f"Import error: {e}")
     st.stop()
 
-# Configure logger for this page
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - DirectChat - %(levelname)s - %(message)s')
 
-# --- Page Configuration ---
-st.title("🤖 Direct AI Chat (Debug)")
-st.caption("Chat directly with an individual AI persona using its configured system prompt for the currently selected mode.")
+# ---------------------------------------------------------------------------
+# Inject chat CSS for consistent styling
+# ---------------------------------------------------------------------------
+gui.inject_chat_css()
 
-# --- Constants ---
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
 PERSONAS = ["Socrates", "Confucius", "Moderator"]
-DEFAULT_PERSONA = PERSONAS[0]
-DEBUG_PAGE_MODES = ["Philosophy", "Bio"]
-DEFAULT_DEBUG_PAGE_MODE = DEBUG_PAGE_MODES[0]
+MODES = ["Philosophy", "Bio"]
 
-SHOW_THINKING_OPTIONS = ["Show Thinking", "Hide Thinking"]
-DEFAULT_SHOW_THINKING_VALUE = SHOW_THINKING_OPTIONS[1] # Default to "Hide Thinking" value
-
-# --- Regex for extracting <think> blocks ---
-THINK_BLOCK_REGEX = re.compile(r"<think>(.*?)</think>", re.DOTALL | re.IGNORECASE)
-
-# --- Helper functions for text processing ---
-def extract_think_block(text: str | None) -> str | None:
-    """Extracts content from the first <think> block found."""
-    if not text: return None
-    match = THINK_BLOCK_REGEX.search(text)
-    return match.group(1).strip() if match else None
-
-def clean_response(text: str | None) -> str:
-    """Removes <think> blocks and surrounding tags."""
-    if not text: return ""
-    return THINK_BLOCK_REGEX.sub('', text).strip()
-
-# --- Persona Selection ---
-# <<< FIX: Initialize debug_chat_persona if not present >>>
-if 'debug_chat_persona' not in st.session_state:
-    st.session_state.debug_chat_persona = DEFAULT_PERSONA
-
-# <<< FIX: Use key="debug_chat_persona" and read from it for index and selected_persona >>>
-selected_persona = st.radio(
-    "Select AI Persona to chat with:",
-    PERSONAS,
-    key="debug_chat_persona", # Widget now manages st.session_state.debug_chat_persona
-    horizontal=True,
-    index=PERSONAS.index(st.session_state.debug_chat_persona) # Read current value for index
+# ---------------------------------------------------------------------------
+# Page Layout
+# ---------------------------------------------------------------------------
+st.markdown(
+    '<div class="phd-header">'
+    '  <h1 class="phd-title">Direct AI Chat</h1>'
+    '  <p class="phd-subtitle">Chat directly with an individual philosopher persona</p>'
+    '</div>',
+    unsafe_allow_html=True,
 )
-# selected_persona is now guaranteed to be the value from st.session_state.debug_chat_persona
+
+# ---------------------------------------------------------------------------
+# Controls
+# ---------------------------------------------------------------------------
+col1, col2 = st.columns(2)
+with col1:
+    selected_persona = st.radio(
+        "Persona:",
+        PERSONAS,
+        key="debug_chat_persona",
+        horizontal=True,
+    )
+with col2:
+    selected_mode = st.radio(
+        "Mode:",
+        MODES,
+        key="debug_local_conversation_mode",
+        horizontal=True,
+    )
+
 persona_key = selected_persona.lower()
+config_key = f"{persona_key}_{selected_mode.lower()}"
 
-# --- Local Mode Selection for Direct Chat ---
-if 'debug_local_conversation_mode' not in st.session_state:
-    st.session_state.debug_local_conversation_mode = DEFAULT_DEBUG_PAGE_MODE
+show_thinking = st.checkbox("Show Thinking", key="debug_show_thinking", value=False)
 
-selected_local_mode = st.radio(
-    "Select Conversation Mode (for this chat):",
-    DEBUG_PAGE_MODES,
-    key='debug_local_conversation_mode', # Changed key to directly manage the state
-    horizontal=True,
-    index=DEBUG_PAGE_MODES.index(st.session_state.debug_local_conversation_mode)
-)
-# selected_local_mode is now st.session_state.debug_local_conversation_mode
-# --- End Local Mode Selection ---
+# ---------------------------------------------------------------------------
+# State initialization
+# ---------------------------------------------------------------------------
+st.session_state.setdefault("debug_messages", {})
+st.session_state.setdefault("debug_chain", None)
+st.session_state.setdefault("debug_system_prompt", "")
+st.session_state.setdefault("current_debug_config_key", None)
 
-# Update info message to reflect local mode selection
-st.info(f"Using AI configurations for **{selected_local_mode} Mode** (selected on this page).")
-
-
-# --- State Initialization for this page (other states) ---
-st.session_state.setdefault('debug_messages', {})
-st.session_state.setdefault('debug_llm', None)
-st.session_state.setdefault('debug_system_prompt', "")
-st.session_state.setdefault('current_debug_config_key', None)
-st.session_state.setdefault('debug_chain', None)
-
-# --- Load LLM, Prompt, and Chain based on current selection (Persona AND Local Mode) ---
-debug_config_key = f"{persona_key}_{selected_local_mode.lower()}"
-logger.debug(f"Running Direct Chat page for config key: {debug_config_key}")
-
-if st.session_state.current_debug_config_key != debug_config_key:
-     st.session_state.debug_llm = None
-     st.session_state.debug_chain = None
-     st.session_state.debug_system_prompt = "Loading..."
-     st.session_state.debug_messages.setdefault(debug_config_key, [])
+# ---------------------------------------------------------------------------
+# Load chain when config changes
+# ---------------------------------------------------------------------------
+if st.session_state.current_debug_config_key != config_key:
+    st.session_state.debug_chain = None
+    st.session_state.debug_system_prompt = ""
+    st.session_state.debug_messages.setdefault(config_key, [])
 
 try:
-    llm, system_prompt_text = load_llm_config_for_persona(persona_key, mode=selected_local_mode)
-
-    if llm and system_prompt_text:
-        prompt_changed = st.session_state.get('debug_system_prompt') != system_prompt_text
-        llm_or_chain_missing = not st.session_state.get('debug_llm') or not st.session_state.get('debug_chain')
-        config_key_changed = st.session_state.current_debug_config_key != debug_config_key
-
-        if config_key_changed or prompt_changed or llm_or_chain_missing:
-            logger.info(f"Configuration requires update for {debug_config_key}. Creating/Updating LLM and Chain.")
-            st.session_state.debug_llm = llm
-            st.session_state.debug_system_prompt = system_prompt_text
-            st.session_state.current_debug_config_key = debug_config_key
-
-            chat_prompt_template = ChatPromptTemplate.from_messages([
-                ("system", system_prompt_text),
+    llm, system_prompt = load_llm_config_for_persona(persona_key, mode=selected_mode)
+    if llm and system_prompt:
+        prompt_changed = st.session_state.debug_system_prompt != system_prompt
+        need_update = (
+            st.session_state.current_debug_config_key != config_key
+            or prompt_changed
+            or st.session_state.debug_chain is None
+        )
+        if need_update:
+            st.session_state.debug_system_prompt = system_prompt
+            st.session_state.current_debug_config_key = config_key
+            template = ChatPromptTemplate.from_messages([
+                ("system", system_prompt),
                 MessagesPlaceholder(variable_name="chat_history"),
-                ("user", "{input}")
+                ("user", "{input}"),
             ])
-            output_parser = StrOutputParser()
-            st.session_state.debug_chain = chat_prompt_template | llm | output_parser
-            logger.info(f"Chain updated successfully for {debug_config_key}.")
+            st.session_state.debug_chain = template | llm | StrOutputParser()
         else:
-             logger.debug(f"Configuration for {debug_config_key} is up-to-date. No chain update needed.")
-             st.session_state.current_debug_config_key = debug_config_key
+            st.session_state.current_debug_config_key = config_key
     else:
-        st.error(f"Failed to load LLM or system prompt for {selected_persona} in {selected_local_mode} mode.")
-        st.session_state.debug_system_prompt = "Error: Could not load configuration."
-        st.session_state.debug_llm = None
+        st.error(f"Failed to load config for {selected_persona} ({selected_mode})")
         st.session_state.debug_chain = None
-
 except Exception as e:
-    st.error(f"An error occurred while loading configuration: {e}")
-    logger.error(f"Error loading LLM/Prompt/Chain for {debug_config_key}", exc_info=True)
-    st.session_state.debug_system_prompt = f"Error loading: {e}"
-    st.session_state.debug_llm = None
+    st.error(f"Config loading error: {e}")
+    logger.exception("Direct Chat config load failed")
     st.session_state.debug_chain = None
 
-# --- Display System Prompt & Controls ---
+# ---------------------------------------------------------------------------
+# System prompt viewer
+# ---------------------------------------------------------------------------
 with st.expander("View System Prompt", expanded=False):
-    current_prompt_display = st.session_state.get("debug_system_prompt", "")
-    if current_prompt_display and not current_prompt_display.startswith("Error") and not current_prompt_display == "Loading...":
-        st.text_area("System Prompt:", value=current_prompt_display, height=200, disabled=True, key=f"sp_{debug_config_key}")
-    elif current_prompt_display == "Loading...":
-         st.info("Loading system prompt...")
+    prompt_text = st.session_state.get("debug_system_prompt", "")
+    if prompt_text:
+        st.text_area("System Prompt:", value=prompt_text, height=200, disabled=True, key=f"sp_{config_key}")
     else:
-        st.warning(current_prompt_display or "System prompt not loaded or failed to load.")
+        st.caption("No prompt loaded.")
 
-st.radio(
-    "Display Thinking:",
-    SHOW_THINKING_OPTIONS,
-    key='debug_show_thinking_radio',
-    horizontal=True,
-    index=SHOW_THINKING_OPTIONS.index(
-        st.session_state.get('debug_show_thinking_radio', DEFAULT_SHOW_THINKING_VALUE)
-    )
-)
 st.divider()
 
-# --- Chat Interface ---
-st.session_state.debug_messages.setdefault(debug_config_key, [])
-st.subheader(f"Chat with {selected_persona} ({selected_local_mode} Mode)")
-current_message_history = st.session_state.debug_messages[debug_config_key]
+# ---------------------------------------------------------------------------
+# Chat display — using the new styled HTML
+# ---------------------------------------------------------------------------
+st.session_state.debug_messages.setdefault(config_key, [])
+history = st.session_state.debug_messages[config_key]
 
-show_thinking_value = st.session_state.get('debug_show_thinking_radio', DEFAULT_SHOW_THINKING_VALUE)
-show_thinking = show_thinking_value == SHOW_THINKING_OPTIONS[0]
+# Get the speaker style for the AI persona
+style = gui.SPEAKER_STYLES.get(persona_key, gui.SPEAKER_STYLES["system"])
 
-for idx, message_data in enumerate(current_message_history):
-    message_type = message_data.get("type")
-    content = message_data.get("content", "")
-    thinking = message_data.get("thinking")
+if not history:
+    st.markdown(
+        '<div class="phd-empty">'
+        f'  <div class="phd-empty-icon">&#x1F4AC;</div>'
+        f'  <div class="phd-empty-text">Chat with {selected_persona}</div>'
+        f'  <div class="phd-empty-hint">Ask a question below to start a direct conversation</div>'
+        '</div>',
+        unsafe_allow_html=True,
+    )
+else:
+    html_parts = ['<div class="phd-container">']
+    for msg in history:
+        msg_type = msg.get("type")
+        content = msg.get("content", "")
+        thinking = msg.get("thinking")
 
-    if message_type == "human":
-        avatar = "👤"
-        with st.chat_message("human", avatar=avatar):
-            st.markdown(content)
-    elif message_type == "ai":
-        avatar = "🤖"
-        with st.chat_message("ai", avatar=avatar):
+        if msg_type == "human":
+            user_style = gui.SPEAKER_STYLES["user"]
+            html_parts.append(
+                f'<div class="phd-turn">'
+                f'  <div class="phd-avatar" style="background:{user_style["color"]};">{user_style["initials"]}</div>'
+                f'  <div class="phd-msg-body">'
+                f'    <div class="phd-msg-header">'
+                f'      <span class="phd-speaker" style="color:{user_style["text_color"]};">You</span>'
+                f'    </div>'
+                f'    <div class="phd-card" style="border-left-color:{user_style["color"]}; background:{user_style["bg"]};">'
+                f'      <div class="phd-content">{gui._esc(content)}</div>'
+                f'    </div>'
+                f'  </div>'
+                f'</div>'
+            )
+        elif msg_type == "ai":
+            html_parts.append(
+                f'<div class="phd-turn">'
+                f'  <div class="phd-avatar" style="background:{style["color"]};">{style["initials"]}</div>'
+                f'  <div class="phd-msg-body">'
+                f'    <div class="phd-msg-header">'
+                f'      <span class="phd-speaker" style="color:{style["text_color"]};">{style["display_name"]}</span>'
+                f'    </div>'
+                f'    <div class="phd-card" style="border-left-color:{style["color"]}; background:{style["bg"]};">'
+                f'      <div class="phd-content">{gui._esc(content)}</div>'
+                f'    </div>'
+                f'  </div>'
+                f'</div>'
+            )
             if thinking and show_thinking:
-                st.caption(f"Thinking: {thinking}")
-            st.markdown(content)
+                html_parts.append(
+                    f'<div class="phd-mod-ctx" style="margin-left:48px;">'
+                    f'  <details>'
+                    f'    <summary class="phd-mod-toggle" style="color:{style["text_color"]};">Thinking</summary>'
+                    f'    <div class="phd-mod-body">{gui._esc(thinking)}</div>'
+                    f'  </details>'
+                    f'</div>'
+                )
+
+    html_parts.append('</div>')
+    st.markdown("\n".join(html_parts), unsafe_allow_html=True)
+
+# ---------------------------------------------------------------------------
+# Chat input
+# ---------------------------------------------------------------------------
+if prompt := st.chat_input(f"Ask {selected_persona} a question..."):
+    if not st.session_state.debug_chain:
+        st.error("Chain not loaded. Cannot chat.")
     else:
-        with st.chat_message("system"):
-             st.warning(f"Unknown message format at index {idx}: {message_data}")
+        # Store user message
+        st.session_state.debug_messages[config_key].append(
+            {"type": "human", "content": prompt, "thinking": None}
+        )
 
+        # Build history for the chain
+        history_for_chain: List[BaseMessage] = []
+        for msg in st.session_state.debug_messages[config_key][:-1]:
+            if msg["type"] == "human":
+                history_for_chain.append(HumanMessage(content=msg["content"]))
+            elif msg["type"] == "ai":
+                history_for_chain.append(AIMessage(content=msg["content"]))
 
-if prompt := st.chat_input(f"What do you want to ask {selected_persona}?"):
-    if not st.session_state.debug_chain or st.session_state.current_debug_config_key != debug_config_key:
-        st.error("Cannot chat. AI Chain is not loaded correctly for the current selection.")
-    else:
-        user_message_data = {"type": "human", "content": prompt, "thinking": None}
-        st.session_state.debug_messages[debug_config_key].append(user_message_data)
-
-        with st.chat_message("human", avatar="👤"):
-            st.markdown(prompt)
-
-        history_for_prompt: List[BaseMessage] = []
-        for msg_data in st.session_state.debug_messages[debug_config_key][:-1]:
-            msg_type = msg_data.get("type")
-            msg_content = msg_data.get("content", "")
-            if msg_type == "human":
-                history_for_prompt.append(HumanMessage(content=msg_content))
-            elif msg_type == "ai":
-                history_for_prompt.append(AIMessage(content=msg_content))
         try:
-            chain = st.session_state.debug_chain
             with st.spinner(f"{selected_persona} is thinking..."):
-                input_data = { "input": prompt, "chat_history": history_for_prompt }
-                raw_response_content = chain.invoke(input_data)
-            thinking_text = extract_think_block(raw_response_content)
-            cleaned_response_content = clean_response(raw_response_content)
-            ai_message_data = {"type": "ai", "content": cleaned_response_content, "thinking": thinking_text}
-            st.session_state.debug_messages[debug_config_key].append(ai_message_data)
+                raw = st.session_state.debug_chain.invoke({
+                    "input": prompt,
+                    "chat_history": history_for_chain,
+                })
+            thinking_text = extract_think_block(raw)
+            cleaned = clean_response(raw)
+            st.session_state.debug_messages[config_key].append(
+                {"type": "ai", "content": cleaned, "thinking": thinking_text}
+            )
             st.rerun()
         except Exception as e:
-            st.error(f"An error occurred during chat invocation: {e}")
-            logger.error(f"Error invoking chain for {debug_config_key}: {e}", exc_info=True)
-            if st.session_state.debug_messages.get(debug_config_key):
-                 st.session_state.debug_messages[debug_config_key].pop()
+            st.error(f"Error: {e}")
+            logger.exception(f"Chain invocation failed for {config_key}")
+            # Remove the user message we just added
+            if st.session_state.debug_messages.get(config_key):
+                st.session_state.debug_messages[config_key].pop()
             st.rerun()
 
-# --- Transcript Display ---
+# ---------------------------------------------------------------------------
+# Transcript and controls
+# ---------------------------------------------------------------------------
 st.divider()
-with st.expander("View/Copy Full Transcript", expanded=False):
-    # <<< FIX: Ensure persona_name is correctly sourced from st.session_state.debug_chat_persona >>>
-    if st.session_state.current_debug_config_key == debug_config_key \
-       and st.session_state.get("debug_system_prompt") \
-       and not st.session_state.debug_system_prompt.startswith("Error") \
-       and not st.session_state.debug_system_prompt == "Loading..." \
-       and 'debug_chat_persona' in st.session_state: # Ensure the key exists
 
-        transcript_list = []
-        system_prompt = st.session_state.debug_system_prompt
-        persona_name = st.session_state.debug_chat_persona # This will now be correctly initialized
-        transcript_mode_header = selected_local_mode
-        message_history = st.session_state.debug_messages.get(debug_config_key, [])
-        
-        show_thinking_in_transcript_value = st.session_state.get('debug_show_thinking_radio', DEFAULT_SHOW_THINKING_VALUE)
-        show_thinking_in_transcript = show_thinking_in_transcript_value == SHOW_THINKING_OPTIONS[0]
-
-
-        transcript_list.append(f"--- System Prompt ({persona_name} - {transcript_mode_header} Mode) ---")
-        transcript_list.append(system_prompt)
-        transcript_list.append("-----------------------------------------------\n")
-
-        if not message_history:
-            transcript_list.append("No messages in this chat session yet.")
-        else:
-            for message_data in message_history:
-                msg_type = message_data.get("type")
-                msg_content = message_data.get("content", "")
-                thinking = message_data.get("thinking")
-                if msg_type == "human":
-                    transcript_list.append(f"USER: {msg_content}")
-                elif msg_type == "ai":
-                    if thinking and show_thinking_in_transcript:
-                        transcript_list.append(f"  THINKING: {thinking}")
-                    transcript_list.append(f"AI ({persona_name}): {msg_content}")
-                else:
-                    transcript_list.append(f"UNKNOWN_TYPE ({msg_type}): {msg_content}")
-                transcript_list.append("-" * 20)
-        full_transcript = "\n".join(transcript_list)
-        st.text_area("Full Transcript:", value=full_transcript, height=400, disabled=True, key=f"transcript_{debug_config_key}")
-    elif st.session_state.get("debug_system_prompt", "").startswith("Error"):
-         st.warning("Cannot show transcript because the AI configuration failed to load.")
-    elif 'debug_chat_persona' not in st.session_state:
-        st.warning("Cannot show transcript because persona state is not initialized.")
+with st.expander("View Full Transcript", expanded=False):
+    if history:
+        lines = []
+        for msg in history:
+            if msg["type"] == "human":
+                lines.append(f"YOU: {msg['content']}")
+            elif msg["type"] == "ai":
+                if msg.get("thinking") and show_thinking:
+                    lines.append(f"  [Thinking]: {msg['thinking']}")
+                lines.append(f"{selected_persona.upper()}: {msg['content']}")
+            lines.append("-" * 30)
+        st.text_area("Transcript:", value="\n".join(lines), height=300, disabled=True, key=f"transcript_{config_key}")
     else:
-        st.caption("Chat with the AI first or ensure configuration is loaded.")
+        st.caption("No messages yet.")
 
-# --- Option to clear debug chat history ---
-st.divider()
-col1_clear, col2_clear = st.columns([1,3])
-with col1_clear:
-    can_clear = debug_config_key in st.session_state.debug_messages and st.session_state.debug_messages[debug_config_key]
-    if st.button(f"Clear Chat History", disabled=not can_clear):
-        st.session_state.debug_messages[debug_config_key] = []
-        logger.info(f"Cleared debug chat history for {debug_config_key}")
-        st.rerun()
+if st.button("Clear Chat History", disabled=not history):
+    st.session_state.debug_messages[config_key] = []
+    st.rerun()


### PR DESCRIPTION
Major UI redesign:
- Custom HTML/CSS chat interface replacing Streamlit's default st.chat_message
- Centered single-column layout with color-coded speakers (blue for Socrates,
  gold for Confucius, gray for Moderator, green for User)
- Avatar circles with speaker initials and left-border accent colors
- Round separators between dialogue rounds (like act breaks in a play)
- Topic card for user's initial question with gradient background
- Collapsible moderator context via HTML <details> elements
- Serif typography (Georgia) for dialogue content, sans-serif for UI chrome
- Animated waiting indicator with bouncing dots
- Completion banner and empty state designs
- Responsive CSS for mobile (768px, 480px breakpoints)

Architecture improvements:
- New core/ package with zero Streamlit dependencies:
  - core/utils.py: Think-block extraction and text cleaning
  - core/config.py: LLM config loading with lru_cache
  - core/persona.py: Single chain factory replacing 3 duplicate files
- direction.py updated to use core.persona and core.utils
- llm_loader.py simplified to thin wrapper around core.config
- app.py rewritten: cleaner session state init, in-memory logging
  (no file handles in session state), consolidated reset/run helpers

Critical fixes from PLAN:
- Moderator max_tokens: 50 -> 200 (was truncating SUMMARY/GUIDANCE output)
- Philosopher max_tokens: 100/110 -> 250 (was truncating with think blocks)

https://claude.ai/code/session_01JZMfqs4YJeQ2gtyd8SzSge