### PR TITLE
Enhance memory awareness, fix bugs, and prepare for Streamlit Cloud

### DIFF
--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -1,0 +1,9 @@
+# Copy this file to secrets.toml for local development,
+# or add these values in Streamlit Cloud dashboard under Settings > Secrets.
+
+# Nebius AI Studio API credentials (required)
+NEBIUS_API_KEY = "your-nebius-api-key-here"
+NEBIUS_API_BASE = "https://api.studio.nebius.com/v1"
+
+# App login password (required)
+app_password = "your-chosen-password"

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,313 @@
+# Agent Handover: Memory Awareness & Codebase Improvement Plan
+
+## Branch
+
+All work MUST be done on branch `claude/enhance-memory-awareness-Z7ZyM`.
+
+---
+
+## Executive Summary
+
+This is a Streamlit-based application where two AI philosopher personas hold a multi-round dialogue on user-provided topics. It uses LangChain with a Nebius-hosted LLM (Qwen3-235B) and has two conversation engines: a legacy `Director` class (`direction.py`) and a newer LangGraph-based agentic engine (`core/graph.py`). The main app (`app.py`) uses the LangGraph engine exclusively.
+
+**The core problem:** Philosophers only see the last 6 turns of conversation history due to a sliding window in `ConversationMemory`, meaning in longer conversations they lose track of the original topic, earlier arguments, and the flow of the discussion. The `max_tokens` setting (250 tokens per response) is also very tight, which compounds context issues. Performance is not a concern — thoroughness is.
+
+---
+
+## Task 1: Investigate and Fix the Core Memory/Context Problem
+
+### 1.1 The Sliding Window Problem (CRITICAL)
+
+**File:** `core/memory.py`
+**Lines:** 14, 38-49
+
+`DEFAULT_WINDOW_SIZE = 6` means `get_history_for_chain()` only returns the last 6 turns. In a 5-round conversation (10 philosopher turns + the user prompt = 11 entries), the philosopher on turn 10 can only see turns 5-10. They have **no visibility** of:
+- The original user question/topic
+- The first 4 turns of the dialogue
+- How the conversation evolved from its starting point
+
+**What to investigate:**
+1. Trace exactly what each philosopher sees at each turn. In `core/graph.py:philosopher_node()` (lines 106-128), the input is built from `memory.get_history_for_chain()` (sliding window) plus `state["last_response"]` (just the previous turn's text). The original `state["topic"]` is ONLY used on `turn_count == 0` (line 109-110). After the first turn, the topic is never referenced again.
+
+2. In `direction.py:run_conversation_streamlit()` (lines 286-287), the same pattern occurs: `memory.get_history_for_chain()` provides limited history, and `input_for_next_speaker` is just the previous response (or response + moderator context).
+
+**Recommended fixes (investigate each, implement what makes sense):**
+
+a) **Always include the original topic in every prompt.** In `philosopher_node()`, the `input_content` on subsequent turns (line 113) should prepend the topic:
+   ```python
+   # Instead of just: input_content = last_response
+   # Do: input_content = f"Original topic: {state['topic']}\n\n{last_response}"
+   ```
+
+b) **Add a conversation summary mechanism.** Rather than (or in addition to) expanding the window, generate a running summary of the full conversation. This could be:
+   - A simple concatenation of all speaker positions so far (not the full text, just key points)
+   - A periodic summarization step (e.g., every 4 turns, summarize what's happened)
+   - A structured "conversation state" that tracks: topic, key positions taken by each philosopher, unresolved questions
+
+c) **Expand or remove the window size for the chain history.** The window of 6 is very conservative. Since the user says performance/time is not a concern, consider:
+   - Increasing `DEFAULT_WINDOW_SIZE` to cover the full conversation (e.g., set it to `total_rounds * 2 + 1`)
+   - Or making it configurable per conversation based on `num_rounds`
+   - The Qwen3-235B model has a large context window, so this shouldn't be a problem
+
+d) **Inject the full conversation context, not just the sliding window.** Modify `get_history_for_chain()` to return ALL turns, or create a new method like `get_full_history_for_chain()` that doesn't apply windowing.
+
+e) **Fix `philosopher_node` to always carry context forward.** Currently on subsequent turns (line 112-113), only `last_response` is passed as input. The philosopher gets no structured recap of what happened before.
+
+### 1.2 The Moderator Context Gap
+
+**File:** `core/memory.py` line 25, `core/graph.py`
+
+The `ConversationMemory` docstring says "Moderator and system turns are never stored." This means the moderator's summaries and guidance — which contain valuable context about the conversation's direction — are completely invisible to the memory system.
+
+In the LangGraph engine (`core/graph.py`), there IS no moderator at all (routing is rule-based, line 5-6). This means the only context between turns is the sliding window of raw philosopher dialogue plus the `last_response`.
+
+**What to investigate:** Should moderator summaries (from the Director path) or some equivalent structured context be incorporated into what philosophers see? In the LangGraph path, should the router node generate a brief context summary?
+
+### 1.3 Long-Term Memory Is Never Queried Effectively
+
+**File:** `core/graph.py` lines 116-124
+
+`PhilosopherMemory` is queried for the topic, but:
+- It uses `LIKE '%topic%'` matching (line 147-148 of `core/memory.py`), which is crude
+- Position summaries are truncated to 200 characters (line 414 of `core/graph.py`) — very lossy
+- The context is prepended to `input_content` but there's no instruction to the philosopher about what to do with it
+- The philosopher's system prompt has NO mention of long-term memory or how to use recalled positions
+
+**What to fix:** At minimum, if long-term memory context is injected, the system prompts should tell the philosopher how to use it. Better: improve the summary quality and matching.
+
+### 1.4 Token Limit Constraints
+
+**File:** `llm_config.json`
+
+All philosophers have `max_tokens: 250`. The prompts ask for 1-3 sentences, which fits. But if you expand context (more history, summaries, etc.), you may want to increase `max_tokens` slightly to give the model room to process the additional context and still produce quality output. Investigate whether 250 is sufficient after expanding context. Consider increasing to 350-400.
+
+Also note: `request_timeout: 90` seconds — with more context, responses may take longer. Ensure this is sufficient.
+
+---
+
+## Task 2: Identify and Fix Other Inefficiencies and Problems
+
+### 2.1 Duplicate Code: `_robust_invoke` Exists in Two Places
+
+**Files:** `direction.py` lines 23-49, `core/graph.py` lines 62-86
+
+These are nearly identical functions. The one in `direction.py` is a method; the one in `graph.py` is a standalone function. They should be consolidated into a shared utility (e.g., in `core/utils.py` or a new `core/invoke.py`).
+
+### 2.2 Chain Recreation on Every Turn (LangGraph path)
+
+**File:** `core/graph.py` line 101
+
+In `philosopher_node()`, `create_chain(next_id, mode=mode)` is called on **every single turn**. This means every philosopher turn:
+1. Reads the prompt file from disk
+2. Calls `load_dotenv()`
+3. Instantiates a new `ChatOpenAI` object
+4. Builds a new `ChatPromptTemplate`
+
+This is wasteful. While `load_default_prompt_text` and `load_llm_params` are `@lru_cache`'d (in `core/config.py`), the `ChatOpenAI` instantiation and `load_llm_config_for_persona` are NOT cached (it calls `load_dotenv()` every time — line 79 of `core/config.py`).
+
+**Fix:** Cache chains at the conversation level. Options:
+- Store chain objects in the graph state (though they're not serializable for checkpointing)
+- Use a module-level cache keyed by `(persona_id, mode)`
+- At minimum, `load_dotenv()` should be called once at startup, not on every persona config load
+
+### 2.3 The `direction.py` Director Is Likely Dead Code
+
+**File:** `direction.py`
+
+The main `app.py` exclusively uses `run_agentic_conversation` from `core/graph.py`. The `Director` class in `direction.py` is only used if someone manually invokes it. However, it's still imported in the codebase structure and may confuse maintainers.
+
+**What to do:** Verify that `direction.py` is not imported anywhere in the active code paths. If it's truly dead code, consider marking it as deprecated or moving it to `v1_archive/`. Do NOT delete it without confirming with the user.
+
+### 2.4 Translator Only Handles Socrates and Confucius
+
+**File:** `translator.py` lines 43-48
+
+```python
+if role not in ["USER", "SOCRATES", "CONFUCIUS"]:
+    continue
+```
+
+This hard-codes only two philosophers. The application now supports 6 philosophers (Socrates, Confucius, Aristotle, Nietzsche, Herodotus, Sima Qian). The translator will silently skip dialogue from Aristotle, Nietzsche, Herodotus, and Sima Qian.
+
+**Fix:** Use the philosopher registry to determine which roles to include:
+```python
+from core.registry import get_display_names
+valid_roles = {"USER"} | {name.upper() for name in get_display_names()}
+if role not in valid_roles:
+    continue
+```
+
+### 2.5 Settings Page Only Lists 3 Personas
+
+**File:** `pages/2_⚙️_Settings.py` line 64
+
+```python
+PERSONAS = ["Socrates", "Confucius", "Moderator"]
+```
+
+This should use the registry:
+```python
+from core.registry import get_display_names
+PERSONAS = get_display_names() + ["Moderator"]
+```
+
+The Direct Chat page (`pages/1_🤖_Direct_Chat.py` line 54) already does this correctly.
+
+### 2.6 `lru_cache` on Mutable Config Won't Invalidate
+
+**File:** `core/config.py` lines 25-26, 48-49
+
+`load_default_prompt_text` and `load_llm_params` use `@lru_cache`. This means:
+- If the user edits a prompt file or `llm_config.json` while the app is running, changes won't be picked up
+- The cache persists for the lifetime of the process
+
+This may be intentional for performance, but it's worth noting. For a Streamlit app that reruns frequently, it's probably fine. But if prompt hot-reloading is desired, the cache would need to be cleared.
+
+### 2.7 The `conversation_completed` Logic Has a Bug
+
+**File:** `app.py` line 185
+
+```python
+st.session_state.conversation_completed = True if success else True
+```
+
+This always sets `conversation_completed = True` regardless of success. It should be:
+```python
+st.session_state.conversation_completed = True
+```
+Or if the intent was to differentiate:
+```python
+st.session_state.conversation_completed = success
+```
+
+This is a logic bug — investigate the intent and fix.
+
+### 2.8 SQLite Connection Leak in `PhilosopherMemory`
+
+**File:** `core/memory.py` lines 101-103, 127-158
+
+`PhilosopherMemory._get_conn()` creates a new `sqlite3.connect()` on every call, and the callers (`record_position`, `recall_positions`, `get_all_topics`) manually close the connection. If an exception occurs between `connect()` and `close()`, the connection leaks. Use context managers:
+
+```python
+with self._get_conn() as conn:
+    conn.execute(...)
+```
+
+Or better, use a single connection per instance.
+
+### 2.9 No Error Handling for Missing Prompt Files in LangGraph Path
+
+**File:** `core/config.py` lines 92-95
+
+When a prompt file is not found, the system falls back to `DEFAULT_FALLBACK_PROMPT = "You are a helpful AI assistant."` This is a generic prompt that would completely break the philosopher persona. This should at least log a WARNING-level message (it logs ERROR, which is good) but should also potentially prevent the conversation from starting rather than silently degrading.
+
+### 2.10 `PhilosopherMemory` Position Recording Is Too Lossy
+
+**File:** `core/graph.py` lines 400-420, `_record_positions()`
+
+Every message from every philosopher gets stored as a "position" — but the summary is just the first 200 characters of their response. This means:
+- A philosopher who says "Well, that's an interesting point. Let me think about what you've said regarding..." would have their position recorded as that preamble, not their actual philosophical position
+- There's no deduplication — the same topic discussed multiple times creates redundant entries
+
+**Consider:** Either improving the summarization (perhaps using the LLM to extract a one-line position) or at minimum, not truncating blindly at 200 characters.
+
+---
+
+## Task 3: Verification and Testing
+
+After making changes, you MUST verify your work:
+
+### 3.1 Run Existing Tests
+
+```bash
+cd /home/user/llm-philosopher-dialogue
+python -m pytest tests/ -v
+```
+
+All existing tests must pass. Key test files:
+- `tests/test_memory.py` — Tests for ConversationMemory (you'll likely need to update these if you change the memory system)
+- `tests/test_graph.py` — Tests for the LangGraph engine (update if you change philosopher_node)
+- `tests/test_utils.py` — Tests for utility functions
+- `tests/test_config.py` — Tests for config loading
+- `tests/test_validation.py` — Input validation tests
+
+### 3.2 Write New Tests for Your Changes
+
+For any new functionality (e.g., expanded memory, topic injection, conversation summaries), write corresponding tests in the `tests/` directory. Follow the existing test patterns:
+- Use `pytest` with classes grouping related tests
+- Mock LLM calls using `unittest.mock.patch`
+- Use the `conftest.py` fixtures (especially `mock_env_vars`)
+
+Specifically, you should test:
+- That the original topic is always visible to philosophers on every turn
+- That expanded memory correctly provides full conversation history
+- That any new summary mechanism produces sensible output
+- That the translator handles all 6 philosophers
+- That the Settings page lists all philosophers
+
+### 3.3 Manual Verification Checks
+
+After code changes, verify:
+1. **Import chains work:** `python -c "from core.memory import ConversationMemory; print('OK')"` (and similar for changed modules)
+2. **No circular imports:** `python -c "import app"` should not error (may fail without Streamlit context, so verify via `python -c "from core.graph import run_agentic_conversation; print('OK')"`)
+3. **Prompt files still load:** Verify that prompt loading works for all 6 philosophers + moderator in both modes
+
+### 3.4 Commit and Push
+
+After all tests pass and verifications complete:
+```bash
+git add <changed files>
+git commit -m "Descriptive message about your changes"
+git push -u origin claude/enhance-memory-awareness-Z7ZyM
+```
+
+---
+
+## File Reference
+
+| File | Purpose | Relevance |
+|------|---------|-----------|
+| `core/memory.py` | Sliding-window memory + PhilosopherMemory (SQLite) | **PRIMARY TARGET** — the memory system |
+| `core/graph.py` | LangGraph conversation engine | **PRIMARY TARGET** — how context is passed between turns |
+| `core/persona.py` | Chain factory (creates LangChain chains) | May need modification for context injection |
+| `core/config.py` | LLM config loading, prompt loading | Review for caching issues |
+| `core/utils.py` | Think-block extraction, direction tag parsing | May need new utilities |
+| `core/registry.py` | Philosopher registry from JSON | Reference for dynamic philosopher lookup |
+| `core/validation.py` | Input validation | No changes expected |
+| `core/models.py` | Typed state models | May need updates for new state fields |
+| `direction.py` | Legacy Director class | Check if dead code; DO NOT delete without asking |
+| `app.py` | Main Streamlit app (uses LangGraph engine) | Fix `conversation_completed` bug |
+| `gui.py` | UI rendering (HTML/CSS) | No changes expected |
+| `translator.py` | Conversation translation | Fix hard-coded philosopher list |
+| `llm_loader.py` | Backward-compatible config wrapper | No changes expected |
+| `llm_config.json` | LLM parameters (model, tokens, temp) | May need `max_tokens` adjustment |
+| `philosophers.json` | Philosopher display config | Reference only |
+| `pages/2_⚙️_Settings.py` | Prompt settings page | Fix hard-coded persona list |
+| `prompts/*.txt` | System prompts for each philosopher | May need updates to reference memory context |
+| `tests/` | Test suite | Must update and extend |
+
+---
+
+## Priority Order
+
+1. **Fix the core memory/context issue** (Task 1.1) — this is the main ask
+2. **Always inject the original topic** (Task 1.1a) — quick win, high impact
+3. **Fix the `conversation_completed` bug** (Task 2.7) — trivial but real bug
+4. **Fix the translator philosopher list** (Task 2.4) — easy fix, user-facing bug
+5. **Fix the Settings page persona list** (Task 2.5) — easy fix, user-facing bug
+6. **Address chain recreation inefficiency** (Task 2.2) — performance improvement
+7. **Fix SQLite connection handling** (Task 2.8) — robustness improvement
+8. **Consolidate duplicate `_robust_invoke`** (Task 2.1) — code quality
+9. **Improve long-term memory integration** (Task 1.3) — enhances conversation quality
+10. **Everything else** — based on your judgment
+
+---
+
+## Important Notes
+
+- This is NOT a real-time application. The user explicitly stated they don't care about latency. Prioritize thoroughness and conversation quality over speed.
+- The LLM is Qwen3-235B hosted on Nebius. It has a large context window. Don't be afraid to send more context.
+- The app has two conversation engines. The active one is `core/graph.py` (LangGraph). The `direction.py` Director is legacy. Focus your memory fixes on the LangGraph path, but also fix the Director if you have time since it's still in the codebase.
+- DO NOT delete files or remove features without checking with the user first.
+- Run ALL tests after making changes. Write new tests for new functionality.
+- Commit and push to `claude/enhance-memory-awareness-Z7ZyM` when done.

--- a/app.py
+++ b/app.py
@@ -182,7 +182,7 @@ def _run_initial_conversation(prompt: str) -> None:
         for m in gen_msgs:
             _write_log(m)
 
-        st.session_state.conversation_completed = True if success else True
+        st.session_state.conversation_completed = success
         if success:
             _maybe_translate(mode)
         _close_log()

--- a/app.py
+++ b/app.py
@@ -12,6 +12,15 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# Bridge Streamlit Cloud secrets into os.environ so core modules
+# (which use os.getenv) work without a .env file.
+try:
+    for key in ("NEBIUS_API_KEY", "NEBIUS_API_BASE"):
+        if key in st.secrets and key not in os.environ:
+            os.environ[key] = st.secrets[key]
+except Exception:
+    pass  # No secrets configured (local dev with .env)
+
 # ---------------------------------------------------------------------------
 # Logging — single basicConfig call for the whole process
 # ---------------------------------------------------------------------------
@@ -71,6 +80,7 @@ _DEFAULTS: Dict[str, Any] = {
     "num_rounds": DEFAULT_NUM_ROUNDS,
     "conversation_mode": DEFAULT_CONVERSATION_MODE,
     "conversation_style": DEFAULT_CONVERSATION_STYLE,
+    "max_tokens": 400,
     "run_conversation_flag": False,
     "conversation_completed": False,
     "prompt_overrides": {},
@@ -166,12 +176,14 @@ def _run_initial_conversation(prompt: str) -> None:
             unsafe_allow_html=True,
         )
 
+        max_tokens = st.session_state.get("max_tokens", 0)
         gen_msgs, final_status, success, thread_id = run_agentic_conversation(
             topic=prompt,
             philosopher_1=starter,
             philosopher_2=philosopher_2,
             num_rounds=num_rounds,
             mode=mode,
+            max_tokens=max_tokens,
         )
         logger.info(f"Agentic conversation finished. success={success}, status={final_status}")
         thinking_placeholder.empty()

--- a/core/config.py
+++ b/core/config.py
@@ -11,6 +11,9 @@ from langchain_openai import ChatOpenAI
 
 logger = logging.getLogger(__name__)
 
+# Load .env once at module import time, not on every persona config load
+load_dotenv()
+
 DEFAULT_MODEL = "meta-llama/Meta-Llama-3.1-70B-Instruct"
 DEFAULT_TIMEOUT = 60
 DEFAULT_TEMPERATURE = 0.7
@@ -76,8 +79,6 @@ def load_llm_config_for_persona(
 
     Returns (ChatOpenAI instance, effective_system_prompt) or (None, None).
     """
-    load_dotenv()
-
     api_key = os.getenv("NEBIUS_API_KEY")
     base_url = os.getenv("NEBIUS_API_BASE")
     if not api_key or not base_url:

--- a/core/config.py
+++ b/core/config.py
@@ -73,6 +73,7 @@ def load_llm_config_for_persona(
     mode: str = "philosophy",
     config_path: str = "llm_config.json",
     prompt_overrides: Optional[Dict[str, str]] = None,
+    max_tokens_override: Optional[int] = None,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """
     Load LLM instance and effective prompt for a persona.
@@ -113,7 +114,7 @@ def load_llm_config_for_persona(
         "request_timeout": params.get("request_timeout", DEFAULT_TIMEOUT),
         "temperature": params.get("temperature", DEFAULT_TEMPERATURE),
     }
-    max_tokens = params.get("max_tokens", DEFAULT_MAX_TOKENS)
+    max_tokens = max_tokens_override or params.get("max_tokens", DEFAULT_MAX_TOKENS)
     if max_tokens is not None:
         llm_kwargs["max_tokens"] = max_tokens
     top_p = params.get("top_p", DEFAULT_TOP_P)

--- a/core/graph.py
+++ b/core/graph.py
@@ -47,6 +47,7 @@ class DialogueState(TypedDict, total=False):
     mode: str                # philosophy or bio
     topic: str               # Original user question
     turn_count: int          # Total turns taken so far
+    max_tokens: int          # Runtime max_tokens override (from verbosity slider)
     is_complete: bool
     error: str
 
@@ -66,8 +67,9 @@ def philosopher_node(state: DialogueState) -> Dict:
     pcfg = get_philosopher(next_id)
     speaker_name = pcfg.display_name if pcfg else next_id
 
-    # Load chain
-    chain = create_chain(next_id, mode=mode)
+    # Load chain (with optional max_tokens override from verbosity slider)
+    max_tokens = state.get("max_tokens", 0) or None
+    chain = create_chain(next_id, mode=mode, max_tokens_override=max_tokens)
     if chain is None:
         return {"error": f"Failed to load chain for {speaker_name}", "is_complete": True}
 
@@ -133,8 +135,9 @@ def philosopher_node(state: DialogueState) -> Dict:
     # Update memory
     memory.add_turn(speaker_name, cleaned_response, current_round)
 
-    # Build message
-    msg = {"role": speaker_name, "content": cleaned_response, "monologue": monologue}
+    # Build message (include intent for UI display)
+    intent = direction.get("intent", "address")
+    msg = {"role": speaker_name, "content": cleaned_response, "monologue": monologue, "intent": intent}
     messages = state.get("messages", []) + [msg]
 
     return {
@@ -283,6 +286,7 @@ def run_agentic_conversation(
     db_path: str = DEFAULT_DB_PATH,
     thread_id: Optional[str] = None,
     on_status: Optional[Callable] = None,
+    max_tokens: int = 0,
 ) -> Tuple[List[Dict[str, Any]], str, bool, str]:
     """Run a self-organizing philosopher conversation.
 
@@ -341,6 +345,7 @@ def run_agentic_conversation(
         "mode": mode.lower(),
         "topic": topic,
         "turn_count": 0,
+        "max_tokens": max_tokens,
         "is_complete": False,
         "error": "",
     }

--- a/core/graph.py
+++ b/core/graph.py
@@ -7,7 +7,6 @@
 import logging
 import os
 import sqlite3
-import time
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict
 
@@ -15,14 +14,11 @@ from langgraph.graph import StateGraph, START, END
 from langgraph.checkpoint.sqlite import SqliteSaver
 
 from core.persona import create_chain
-from core.utils import extract_and_clean, parse_direction_tag
+from core.utils import extract_and_clean, parse_direction_tag, robust_invoke
 from core.memory import ConversationMemory, PhilosopherMemory
 from core.registry import get_philosopher_ids, get_philosopher
 
 logger = logging.getLogger(__name__)
-
-MAX_RETRIES = 3
-RETRY_DELAY = 2  # seconds
 
 DEFAULT_DB_PATH = os.path.join(
     os.path.dirname(os.path.dirname(__file__)), "data", "conversations.db"
@@ -59,33 +55,6 @@ class DialogueState(TypedDict, total=False):
 # Node functions
 # ---------------------------------------------------------------------------
 
-def _robust_invoke(chain: Any, input_dict: Dict, actor_name: str, round_num: int) -> Tuple[Optional[str], Optional[str]]:
-    """Invoke a chain with retry logic. Returns (clean_response, monologue)."""
-    if chain is None:
-        logger.error(f"Round {round_num}: Cannot invoke {actor_name}, chain is None.")
-        return None, None
-    for attempt in range(1, MAX_RETRIES + 1):
-        try:
-            logger.info(f"Round {round_num}: Requesting {actor_name} (Attempt {attempt}/{MAX_RETRIES})")
-            start_time = time.time()
-            raw = chain.invoke(input_dict)
-            raw_str = str(raw) if raw is not None else None
-            elapsed = time.time() - start_time
-            logger.info(f"Round {round_num}: {actor_name} responded in {elapsed:.2f}s.")
-            if raw_str is not None and raw_str.strip():
-                return extract_and_clean(raw_str)
-            elif raw_str == "":
-                return "", None
-            else:
-                raise ValueError(f"Empty response from {actor_name}")
-        except Exception as e:
-            logger.error(f"Round {round_num}: {actor_name} failed (Attempt {attempt}): {e}", exc_info=True)
-            if attempt == MAX_RETRIES:
-                return None, None
-            time.sleep(RETRY_DELAY)
-    return None, None
-
-
 def philosopher_node(state: DialogueState) -> Dict:
     """Invoke the next speaker's chain and parse direction signals."""
     next_id = state["next_speaker_id"]
@@ -105,29 +74,35 @@ def philosopher_node(state: DialogueState) -> Dict:
     # Build memory from serialized turns
     memory = ConversationMemory.from_list(state.get("memory_turns", []))
 
-    # Build input content
+    # Build input content — always include the original topic for context
+    topic = state["topic"]
     if turn_count == 0:
-        input_content = state["topic"]
+        input_content = topic
     else:
         last_response = state.get("last_response", "")
-        input_content = last_response
+        input_content = f"Original topic: {topic}\n\n{last_response}"
 
-    # Inject long-term memory context
+    # Inject long-term memory context with usage instructions
     long_term_ctx = ""
     try:
         phil_mem = PhilosopherMemory(next_id)
-        long_term_ctx = phil_mem.get_context_for_prompt(state["topic"], limit=3)
+        long_term_ctx = phil_mem.get_context_for_prompt(topic, limit=3)
     except Exception as e:
         logger.warning(f"Long-term memory lookup failed for {next_id}: {e}")
 
     if long_term_ctx:
-        input_content = f"{long_term_ctx}\n\n{input_content}"
+        input_content = (
+            f"{long_term_ctx}\n"
+            f"(Use the above recalled positions to maintain consistency "
+            f"with your prior views, or explain how your thinking has evolved.)\n\n"
+            f"{input_content}"
+        )
 
-    # Invoke
-    history = memory.get_history_for_chain()
+    # Invoke with full conversation history (no sliding window)
+    history = memory.get_full_history_for_chain()
     invoke_input = {"input": input_content, "chat_history": history}
 
-    response, monologue = _robust_invoke(chain, invoke_input, speaker_name, current_round)
+    response, monologue = robust_invoke(chain, invoke_input, speaker_name, current_round)
 
     if response is None:
         return {
@@ -398,21 +373,28 @@ def run_agentic_conversation(
 
 
 def _record_positions(state: DialogueState, topic: str, session_id: str) -> None:
-    """After a conversation, record each philosopher's positions in long-term memory."""
+    """After a conversation, record each philosopher's final position in long-term memory.
+
+    Only records the last message from each philosopher to avoid redundant entries.
+    Stores the full response (up to 500 chars) rather than blindly truncating.
+    """
     try:
+        # Collect last message per philosopher to avoid duplicates
+        last_msg_by_role: Dict[str, str] = {}
         for msg in state.get("messages", []):
             role = msg.get("role", "")
             content = msg.get("content", "")
             if role == "system" or not content:
                 continue
-            # Find the philosopher ID for this role (display name)
+            last_msg_by_role[role] = content
+
+        for role, content in last_msg_by_role.items():
             for pid in get_philosopher_ids():
                 pcfg = get_philosopher(pid)
                 if pcfg and pcfg.display_name == role:
                     mem = PhilosopherMemory(pid)
-                    # Truncate to first 200 chars as position summary
-                    summary = content[:200].strip()
-                    if len(content) > 200:
+                    summary = content[:500].strip()
+                    if len(content) > 500:
                         summary += "..."
                     mem.record_position(topic, summary, session_id)
                     break

--- a/core/memory.py
+++ b/core/memory.py
@@ -11,7 +11,7 @@ from langchain_core.messages import HumanMessage, BaseMessage
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_WINDOW_SIZE = 6
+DEFAULT_WINDOW_SIZE = 50  # Large enough to cover full conversations
 
 
 @dataclass
@@ -45,6 +45,18 @@ class ConversationMemory:
         window = self._turns[-self.window_size:] if len(self._turns) > self.window_size else self._turns[:]
         messages: List[BaseMessage] = []
         for turn in window:
+            formatted = f"[{turn['speaker']}, Round {turn['round']}]: {turn['content']}"
+            messages.append(HumanMessage(content=formatted))
+        return messages
+
+    def get_full_history_for_chain(self) -> List[BaseMessage]:
+        """Return ALL turns as LangChain messages, ignoring window_size.
+
+        Use this when full conversation context is needed, e.g. for
+        philosopher nodes that need to see the entire conversation.
+        """
+        messages: List[BaseMessage] = []
+        for turn in self._turns:
             formatted = f"[{turn['speaker']}, Round {turn['round']}]: {turn['content']}"
             messages.append(HumanMessage(content=formatted))
         return messages
@@ -104,37 +116,35 @@ class PhilosopherMemory:
 
     def _ensure_table(self) -> None:
         try:
-            conn = self._get_conn()
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS philosopher_memory (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    philosopher_id TEXT NOT NULL,
-                    topic TEXT NOT NULL,
-                    position TEXT NOT NULL,
-                    session_id TEXT,
-                    created_at TEXT NOT NULL
-                )
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_phil_topic
-                ON philosopher_memory (philosopher_id, topic)
-            """)
-            conn.commit()
-            conn.close()
+            with self._get_conn() as conn:
+                conn.execute("""
+                    CREATE TABLE IF NOT EXISTS philosopher_memory (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        philosopher_id TEXT NOT NULL,
+                        topic TEXT NOT NULL,
+                        position TEXT NOT NULL,
+                        session_id TEXT,
+                        created_at TEXT NOT NULL
+                    )
+                """)
+                conn.execute("""
+                    CREATE INDEX IF NOT EXISTS idx_phil_topic
+                    ON philosopher_memory (philosopher_id, topic)
+                """)
+                conn.commit()
         except Exception as e:
             logger.error(f"PhilosopherMemory table creation failed: {e}")
 
     def record_position(self, topic: str, position_summary: str, session_id: str = "") -> None:
         """Record a philosopher's position on a topic."""
         try:
-            conn = self._get_conn()
-            conn.execute(
-                "INSERT INTO philosopher_memory (philosopher_id, topic, position, session_id, created_at) "
-                "VALUES (?, ?, ?, ?, ?)",
-                (self.philosopher_id, topic, position_summary, session_id, datetime.now().isoformat()),
-            )
-            conn.commit()
-            conn.close()
+            with self._get_conn() as conn:
+                conn.execute(
+                    "INSERT INTO philosopher_memory (philosopher_id, topic, position, session_id, created_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (self.philosopher_id, topic, position_summary, session_id, datetime.now().isoformat()),
+                )
+                conn.commit()
             logger.info(f"Recorded position for {self.philosopher_id} on '{topic}'")
         except Exception as e:
             logger.error(f"Failed to record position: {e}")
@@ -142,18 +152,17 @@ class PhilosopherMemory:
     def recall_positions(self, topic: str, limit: int = 5) -> List[Dict[str, str]]:
         """Recall previous positions on a topic (fuzzy match via LIKE)."""
         try:
-            conn = self._get_conn()
-            cursor = conn.execute(
-                "SELECT topic, position, created_at FROM philosopher_memory "
-                "WHERE philosopher_id = ? AND topic LIKE ? "
-                "ORDER BY created_at DESC LIMIT ?",
-                (self.philosopher_id, f"%{topic}%", limit),
-            )
-            results = [
-                {"topic": row[0], "position": row[1], "created_at": row[2]}
-                for row in cursor.fetchall()
-            ]
-            conn.close()
+            with self._get_conn() as conn:
+                cursor = conn.execute(
+                    "SELECT topic, position, created_at FROM philosopher_memory "
+                    "WHERE philosopher_id = ? AND topic LIKE ? "
+                    "ORDER BY created_at DESC LIMIT ?",
+                    (self.philosopher_id, f"%{topic}%", limit),
+                )
+                results = [
+                    {"topic": row[0], "position": row[1], "created_at": row[2]}
+                    for row in cursor.fetchall()
+                ]
             return results
         except Exception as e:
             logger.error(f"Failed to recall positions: {e}")
@@ -162,13 +171,12 @@ class PhilosopherMemory:
     def get_all_topics(self) -> List[str]:
         """Return all unique topics this philosopher has discussed."""
         try:
-            conn = self._get_conn()
-            cursor = conn.execute(
-                "SELECT DISTINCT topic FROM philosopher_memory WHERE philosopher_id = ? ORDER BY topic",
-                (self.philosopher_id,),
-            )
-            topics = [row[0] for row in cursor.fetchall()]
-            conn.close()
+            with self._get_conn() as conn:
+                cursor = conn.execute(
+                    "SELECT DISTINCT topic FROM philosopher_memory WHERE philosopher_id = ? ORDER BY topic",
+                    (self.philosopher_id,),
+                )
+                topics = [row[0] for row in cursor.fetchall()]
             return topics
         except Exception as e:
             logger.error(f"Failed to get topics: {e}")

--- a/core/persona.py
+++ b/core/persona.py
@@ -15,6 +15,7 @@ def create_chain(
     persona_id: str,
     mode: str = "philosophy",
     prompt_overrides: Optional[Dict[str, str]] = None,
+    max_tokens_override: Optional[int] = None,
 ) -> Optional[Any]:
     """
     Create a LangChain chain for any persona/mode combination.
@@ -26,13 +27,15 @@ def create_chain(
         persona_id: Lowercase persona name (e.g. "socrates", "confucius", "moderator").
         mode: Conversation mode (e.g. "philosophy", "bio").
         prompt_overrides: Optional dict of override prompts keyed by "persona_mode".
+        max_tokens_override: Optional runtime override for max_tokens.
 
     Returns:
         A LangChain chain, or None on failure.
     """
     logger.info(f"Creating chain for '{persona_id}' mode '{mode}'")
     llm, system_prompt = load_llm_config_for_persona(
-        persona_id, mode=mode, prompt_overrides=prompt_overrides
+        persona_id, mode=mode, prompt_overrides=prompt_overrides,
+        max_tokens_override=max_tokens_override,
     )
 
     if not llm or not system_prompt:

--- a/core/utils.py
+++ b/core/utils.py
@@ -12,9 +12,9 @@ RETRY_DELAY = 2  # seconds
 
 THINK_BLOCK_REGEX = re.compile(r"<think>(.*?)</think>", re.DOTALL | re.IGNORECASE)
 
-# Direction tag: [NEXT: <name> | INTENT: <intent>]
+# Direction tag: [NEXT: <name> | INTENT: <intent>] or [NEXT: <name> | <intent>]
 DIRECTION_TAG_REGEX = re.compile(
-    r"\[NEXT:\s*(?P<next>[^|]+?)\s*\|\s*INTENT:\s*(?P<intent>\w+)\s*\]",
+    r"\[NEXT:\s*(?P<next>[^|]+?)\s*\|\s*(?:INTENT:\s*)?(?P<intent>\w+)\s*\]",
     re.IGNORECASE,
 )
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,7 +1,14 @@
-# core/utils.py — Shared utilities (think-block extraction, text cleaning, direction tags).
+# core/utils.py — Shared utilities (think-block extraction, text cleaning, direction tags, LLM invocation).
 
+import logging
 import re
-from typing import Optional, Tuple, Dict
+import time
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+MAX_RETRIES = 3
+RETRY_DELAY = 2  # seconds
 
 THINK_BLOCK_REGEX = re.compile(r"<think>(.*?)</think>", re.DOTALL | re.IGNORECASE)
 
@@ -36,6 +43,44 @@ def extract_and_clean(raw_response: Optional[str]) -> Tuple[str, Optional[str]]:
     if not cleaned and raw_response:
         return "", monologue
     return cleaned, monologue
+
+
+def robust_invoke(
+    chain: Any, input_dict: Dict, actor_name: str, round_num: int
+) -> Tuple[Optional[str], Optional[str]]:
+    """Invoke a chain with retry logic. Returns (clean_response, monologue).
+
+    Shared between the LangGraph engine (core/graph.py) and the legacy
+    Director class (direction.py).
+    """
+    if chain is None:
+        logger.error(f"Round {round_num}: Cannot invoke {actor_name}, chain is None.")
+        return None, None
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            logger.info(
+                f"Round {round_num}: Requesting {actor_name} (Attempt {attempt}/{MAX_RETRIES})"
+            )
+            start_time = time.time()
+            raw = chain.invoke(input_dict)
+            raw_str = str(raw) if raw is not None else None
+            elapsed = time.time() - start_time
+            logger.info(f"Round {round_num}: {actor_name} responded in {elapsed:.2f}s.")
+            if raw_str is not None and raw_str.strip():
+                return extract_and_clean(raw_str)
+            elif raw_str == "":
+                return "", None
+            else:
+                raise ValueError(f"Empty response from {actor_name}")
+        except Exception as e:
+            logger.error(
+                f"Round {round_num}: {actor_name} failed (Attempt {attempt}): {e}",
+                exc_info=True,
+            )
+            if attempt == MAX_RETRIES:
+                return None, None
+            time.sleep(RETRY_DELAY)
+    return None, None
 
 
 def parse_direction_tag(text: str) -> Tuple[str, Dict[str, str]]:

--- a/direction.py
+++ b/direction.py
@@ -5,13 +5,9 @@ import logging
 from typing import List, Tuple, Dict, Any, Optional
 
 from core.persona import create_chain
-from core.utils import extract_and_clean
+from core.utils import extract_and_clean, robust_invoke
 from core.memory import ConversationMemory
 from core.registry import get_philosopher_ids, get_philosopher
-
-# --- Configuration ---
-MAX_RETRIES = 3
-RETRY_DELAY = 2  # seconds
 
 logger = logging.getLogger(__name__)
 
@@ -21,32 +17,8 @@ class Director:
         logger.info("Director initialized (chains will be loaded per conversation mode/resume).")
 
     def _robust_invoke(self, chain: Any, input_dict: Dict[str, Any], actor_name: str, round_num: int) -> Tuple[Optional[str], Optional[str]]:
-        """Invoke a chain with retry logic. Returns (clean_response, monologue)."""
-        if chain is None:
-            logger.error(f"Round {round_num}: Cannot invoke {actor_name}, chain is None.")
-            return None, None
-        for attempt in range(1, MAX_RETRIES + 1):
-            try:
-                logger.info(f"Round {round_num}: Requesting {actor_name} (Attempt {attempt}/{MAX_RETRIES})")
-                start_time = time.time()
-                raw_response_obj = chain.invoke(input_dict)
-                raw_response = str(raw_response_obj) if raw_response_obj is not None else None
-                elapsed = time.time() - start_time
-                logger.info(f"Round {round_num}: {actor_name} responded in {elapsed:.2f}s.")
-                if raw_response is not None and raw_response.strip():
-                    return extract_and_clean(raw_response)
-                elif raw_response == "":
-                    return "", None
-                else:
-                    raise ValueError(f"Empty response from {actor_name}: '{raw_response}'")
-            except Exception as e:
-                logger.error(f"Round {round_num}: {actor_name} failed (Attempt {attempt}): {e}", exc_info=True)
-                if attempt == MAX_RETRIES:
-                    logger.error(f"Round {round_num}: {actor_name} failed permanently.")
-                    return None, None
-                logger.info(f"Retrying in {RETRY_DELAY}s...")
-                time.sleep(RETRY_DELAY)
-        return None, None
+        """Invoke a chain with retry logic. Delegates to shared robust_invoke."""
+        return robust_invoke(chain, input_dict, actor_name, round_num)
 
     def _robust_stream(self, chain: Any, input_dict: Dict[str, Any], actor_name: str,
                        round_num: int, on_token_callback: Any = None
@@ -283,7 +255,7 @@ class Director:
                     on_status(f"{current_speaker_name} is thinking... (Round {round_num_for_log} of {num_rounds})")
 
                 # Build input with conversation memory
-                history = memory.get_history_for_chain()
+                history = memory.get_full_history_for_chain()
                 invoke_input = {"input": input_content_for_speaker, "chat_history": history}
                 if stream:
                     speaker_response, speaker_monologue = self._robust_stream(
@@ -324,6 +296,7 @@ class Director:
                     current_conversation_state["messages_log"].append({"role": "system", "content": mod_output_text, "monologue": None})
 
                     current_conversation_state["input_for_next_speaker"] = (
+                        f"Original topic: {initial_input}\n\n"
                         f"{speaker_response}\n\n"
                         f"--- Moderator Context ---\n"
                         f"Summary: {summary}\n"
@@ -331,7 +304,9 @@ class Director:
                         f"--- End Context ---"
                     )
                 else:
-                    current_conversation_state["input_for_next_speaker"] = speaker_response
+                    current_conversation_state["input_for_next_speaker"] = (
+                        f"Original topic: {initial_input}\n\n{speaker_response}"
+                    )
 
             final_status_msg = f"{run_mode_desc} conversation ('{mode}' mode) completed after {num_rounds} rounds."
             logger.info(final_status_msg)

--- a/gui.py
+++ b/gui.py
@@ -517,10 +517,15 @@ def _render_round_separator(round_num: int) -> str:
     )
 
 
-def _render_message(role: str, content: str, round_num: int = 0) -> str:
+def _render_message(role: str, content: str, round_num: int = 0, intent: str = "") -> str:
     """Render a philosopher or user message as a chat turn."""
     style = _get_style(role)
-    meta = f"Round {round_num}" if round_num > 0 else ""
+    meta_parts = []
+    if round_num > 0:
+        meta_parts.append(f"Round {round_num}")
+    if intent:
+        meta_parts.append(intent)
+    meta = " &middot; ".join(meta_parts)
     border_color = style.get("border", style["color"])
     return (
         f'<div class="phd-turn">'
@@ -759,6 +764,16 @@ def display_settings_popover(model_info: Dict[str, str]):
             help="One round = one response from each philosopher.",
         )
 
+        st.slider(
+            "Verbosity (max tokens):",
+            min_value=100,
+            max_value=800,
+            step=50,
+            key="max_tokens",
+            help="Controls response length. Lower = more concise, higher = more expansive. "
+                 "Default config values are used when set to 0.",
+        )
+
         # --- Display Section ---
         st.markdown('<div class="ws-settings-section">Display</div>', unsafe_allow_html=True)
 
@@ -825,7 +840,8 @@ def display_conversation(
                 current_round = round_num
                 html_parts.append(_render_round_separator(round_num))
 
-            html_parts.append(_render_message(role, content, round_num))
+            intent = msg.get("intent", "")
+            html_parts.append(_render_message(role, content, round_num, intent=intent))
             continue
 
         # --- System messages ---

--- a/llm_config.json
+++ b/llm_config.json
@@ -6,12 +6,12 @@
     "top_p": 0.95,
     "presence_penalty": 0.0,
     "frequency_penalty": 0.0,
-    "request_timeout": 60
+    "request_timeout": 120
   },
   "socrates": {
     "model_name": "Qwen/Qwen3-235B-A22B-Instruct-2507",
     "temperature": 0.5,
-    "max_tokens": 250,
+    "max_tokens": 400,
     "top_p": 0.95,
     "presence_penalty": 0.1,
     "frequency_penalty": 0.1,
@@ -20,7 +20,7 @@
   "confucius": {
     "model_name": "Qwen/Qwen3-235B-A22B-Instruct-2507",
     "temperature": 0.6,
-    "max_tokens": 250,
+    "max_tokens": 400,
     "top_p": 0.9,
     "presence_penalty": 0.0,
     "frequency_penalty": 0.0,
@@ -29,7 +29,7 @@
   "aristotle": {
     "model_name": "Qwen/Qwen3-235B-A22B-Instruct-2507",
     "temperature": 0.5,
-    "max_tokens": 250,
+    "max_tokens": 400,
     "top_p": 0.95,
     "presence_penalty": 0.1,
     "frequency_penalty": 0.05,
@@ -38,7 +38,7 @@
   "nietzsche": {
     "model_name": "Qwen/Qwen3-235B-A22B-Instruct-2507",
     "temperature": 0.7,
-    "max_tokens": 250,
+    "max_tokens": 400,
     "top_p": 0.95,
     "presence_penalty": 0.1,
     "frequency_penalty": 0.1,
@@ -47,7 +47,7 @@
   "herodotus": {
     "model_name": "Qwen/Qwen3-235B-A22B-Instruct-2507",
     "temperature": 0.6,
-    "max_tokens": 250,
+    "max_tokens": 400,
     "top_p": 0.95,
     "presence_penalty": 0.05,
     "frequency_penalty": 0.05,
@@ -56,7 +56,7 @@
   "simaqian": {
     "model_name": "Qwen/Qwen3-235B-A22B-Instruct-2507",
     "temperature": 0.55,
-    "max_tokens": 250,
+    "max_tokens": 400,
     "top_p": 0.9,
     "presence_penalty": 0.05,
     "frequency_penalty": 0.05,

--- a/pages/1_🤖_Direct_Chat.py
+++ b/pages/1_🤖_Direct_Chat.py
@@ -6,6 +6,15 @@ import sys
 import logging
 
 import streamlit as st
+
+# Bridge Streamlit Cloud secrets into os.environ
+try:
+    for _key in ("NEBIUS_API_KEY", "NEBIUS_API_BASE"):
+        if _key in st.secrets and _key not in os.environ:
+            os.environ[_key] = st.secrets[_key]
+except Exception:
+    pass
+
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.messages import AIMessage, HumanMessage, BaseMessage

--- a/pages/2_⚙️_Settings.py
+++ b/pages/2_⚙️_Settings.py
@@ -30,6 +30,7 @@ if parent_dir not in sys.path:
 
 try:
     from llm_loader import load_default_prompt_text
+    from core.registry import get_display_names
     import gui
 except ImportError as e:
     st.error(f"Import error: {e}")
@@ -61,7 +62,7 @@ st.markdown(
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-PERSONAS = ["Socrates", "Confucius", "Moderator"]
+PERSONAS = get_display_names() + ["Moderator"]
 MODES = ["Philosophy", "Bio"]
 FALLBACK_TEXT = "Default prompt file not found."
 

--- a/pages/2_⚙️_Settings.py
+++ b/pages/2_⚙️_Settings.py
@@ -7,6 +7,14 @@ import logging
 
 import streamlit as st
 
+# Bridge Streamlit Cloud secrets into os.environ
+try:
+    for _key in ("NEBIUS_API_KEY", "NEBIUS_API_BASE"):
+        if _key in st.secrets and _key not in os.environ:
+            os.environ[_key] = st.secrets[_key]
+except Exception:
+    pass
+
 # ---------------------------------------------------------------------------
 # Authentication
 # ---------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-langchain
-langchain-openai
-langgraph
-langgraph-checkpoint-sqlite
-python-dotenv
-streamlit
-pytest
+langchain>=1.2,<2
+langchain-openai>=1.1,<2
+langgraph>=1.1,<2
+langgraph-checkpoint-sqlite>=3,<4
+python-dotenv>=1.0,<2
+streamlit>=1.54,<2

--- a/tests/test_direction.py
+++ b/tests/test_direction.py
@@ -4,7 +4,8 @@ import time
 import pytest
 from unittest.mock import patch, MagicMock, call
 
-from direction import Director, MAX_RETRIES
+from direction import Director
+from core.utils import MAX_RETRIES
 
 
 # ---------------------------------------------------------------------------
@@ -56,13 +57,13 @@ class TestRobustInvoke:
         assert result == "Visible response"
         assert monologue == "internal"
 
-    @patch("direction.time.sleep")  # skip actual sleep in tests
+    @patch("core.utils.time.sleep")  # skip actual sleep in tests
     def test_retry_then_success(self, mock_sleep):
         chain = _make_mock_chain([Exception("timeout"), "recovered"])
         result, monologue = self.director._robust_invoke(chain, {"input": "test"}, "TestActor", 1)
         assert result == "recovered"
 
-    @patch("direction.time.sleep")
+    @patch("core.utils.time.sleep")
     def test_permanent_failure(self, mock_sleep):
         chain = _make_mock_chain([Exception("fail")] * MAX_RETRIES)
         result, monologue = self.director._robust_invoke(chain, {"input": "test"}, "TestActor", 1)

--- a/tests/test_memory_awareness.py
+++ b/tests/test_memory_awareness.py
@@ -1,0 +1,294 @@
+# tests/test_memory_awareness.py — Tests for memory awareness improvements.
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from langchain_core.messages import HumanMessage
+
+from core.memory import ConversationMemory, DEFAULT_WINDOW_SIZE
+from core.graph import philosopher_node, _record_positions, DialogueState
+from core.utils import robust_invoke, MAX_RETRIES
+from translator import format_conversation_for_translation
+
+
+# ---------------------------------------------------------------------------
+# ConversationMemory: full history method
+# ---------------------------------------------------------------------------
+
+class TestFullHistory:
+    def test_get_full_history_returns_all_turns(self):
+        """get_full_history_for_chain should return every turn regardless of window_size."""
+        mem = ConversationMemory(window_size=3)
+        for i in range(10):
+            mem.add_turn("Speaker", f"Turn {i}", round_number=(i // 2) + 1)
+        full = mem.get_full_history_for_chain()
+        assert len(full) == 10
+
+    def test_get_full_history_format(self):
+        mem = ConversationMemory()
+        mem.add_turn("Socrates", "Virtue is knowledge.", 1)
+        full = mem.get_full_history_for_chain()
+        assert len(full) == 1
+        assert isinstance(full[0], HumanMessage)
+        assert full[0].content == "[Socrates, Round 1]: Virtue is knowledge."
+
+    def test_full_history_empty_memory(self):
+        mem = ConversationMemory()
+        assert mem.get_full_history_for_chain() == []
+
+    def test_default_window_size_is_large(self):
+        """DEFAULT_WINDOW_SIZE should be large enough for full conversations."""
+        assert DEFAULT_WINDOW_SIZE >= 20
+
+
+# ---------------------------------------------------------------------------
+# Topic injection: philosopher always sees original topic
+# ---------------------------------------------------------------------------
+
+class TestTopicInjection:
+    @patch("core.graph.PhilosopherMemory")
+    @patch("core.graph.create_chain")
+    def test_topic_included_on_first_turn(self, mock_create_chain, mock_phil_mem):
+        """On turn 0, input_content should be the topic itself."""
+        mock_chain = MagicMock()
+        mock_chain.invoke.return_value = "Response text."
+        mock_create_chain.return_value = mock_chain
+
+        mock_mem_instance = MagicMock()
+        mock_mem_instance.get_context_for_prompt.return_value = ""
+        mock_phil_mem.return_value = mock_mem_instance
+
+        state = _make_base_state(turn_count=0)
+        philosopher_node(state)
+
+        call_args = mock_chain.invoke.call_args[0][0]
+        assert "What is virtue?" in call_args["input"]
+
+    @patch("core.graph.PhilosopherMemory")
+    @patch("core.graph.create_chain")
+    def test_topic_included_on_subsequent_turns(self, mock_create_chain, mock_phil_mem):
+        """On turn > 0, input_content should contain 'Original topic:'."""
+        mock_chain = MagicMock()
+        mock_chain.invoke.return_value = "Response text."
+        mock_create_chain.return_value = mock_chain
+
+        mock_mem_instance = MagicMock()
+        mock_mem_instance.get_context_for_prompt.return_value = ""
+        mock_phil_mem.return_value = mock_mem_instance
+
+        state = _make_base_state(turn_count=3)
+        state["last_response"] = "Previous philosopher said something."
+        philosopher_node(state)
+
+        call_args = mock_chain.invoke.call_args[0][0]
+        assert "Original topic: What is virtue?" in call_args["input"]
+        assert "Previous philosopher said something." in call_args["input"]
+
+    @patch("core.graph.PhilosopherMemory")
+    @patch("core.graph.create_chain")
+    def test_full_history_used_not_windowed(self, mock_create_chain, mock_phil_mem):
+        """philosopher_node should use get_full_history_for_chain, passing all turns."""
+        mock_chain = MagicMock()
+        mock_chain.invoke.return_value = "Response."
+        mock_create_chain.return_value = mock_chain
+
+        mock_mem_instance = MagicMock()
+        mock_mem_instance.get_context_for_prompt.return_value = ""
+        mock_phil_mem.return_value = mock_mem_instance
+
+        # Create state with many memory turns
+        turns = [
+            {"speaker": f"Speaker{i}", "content": f"Turn {i}", "round": (i // 2) + 1}
+            for i in range(12)
+        ]
+        state = _make_base_state(turn_count=12)
+        state["memory_turns"] = turns
+
+        philosopher_node(state)
+
+        call_args = mock_chain.invoke.call_args[0][0]
+        # All 12 turns should be in chat_history
+        assert len(call_args["chat_history"]) == 12
+
+
+# ---------------------------------------------------------------------------
+# Long-term memory context includes usage instructions
+# ---------------------------------------------------------------------------
+
+class TestLongTermMemoryContext:
+    @patch("core.graph.PhilosopherMemory")
+    @patch("core.graph.create_chain")
+    def test_long_term_memory_includes_instructions(self, mock_create_chain, mock_phil_mem):
+        """When long-term memory is present, instructions should be included."""
+        mock_chain = MagicMock()
+        mock_chain.invoke.return_value = "Response."
+        mock_create_chain.return_value = mock_chain
+
+        mock_mem_instance = MagicMock()
+        mock_mem_instance.get_context_for_prompt.return_value = (
+            "[Previous discussions on related topics:]\n"
+            "- On 'virtue': Virtue is knowledge."
+        )
+        mock_phil_mem.return_value = mock_mem_instance
+
+        state = _make_base_state(turn_count=0)
+        philosopher_node(state)
+
+        call_args = mock_chain.invoke.call_args[0][0]
+        assert "recalled positions" in call_args["input"].lower() or \
+               "consistency" in call_args["input"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Position recording: deduplicated and not truncated at 200 chars
+# ---------------------------------------------------------------------------
+
+class TestPositionRecording:
+    @patch("core.graph.PhilosopherMemory")
+    def test_records_only_last_message_per_philosopher(self, mock_phil_mem):
+        """Should only record the final message from each philosopher."""
+        mock_mem_instance = MagicMock()
+        mock_phil_mem.return_value = mock_mem_instance
+
+        state = DialogueState(
+            messages=[
+                {"role": "Socrates", "content": "Early thought.", "monologue": None},
+                {"role": "Confucius", "content": "Early wisdom.", "monologue": None},
+                {"role": "Socrates", "content": "Final thought.", "monologue": None},
+                {"role": "Confucius", "content": "Final wisdom.", "monologue": None},
+            ],
+            philosopher_1_id="socrates",
+            philosopher_2_id="confucius",
+            topic="What is virtue?",
+        )
+
+        _record_positions(state, "What is virtue?", "session-123")
+
+        # Should have recorded exactly 2 positions (one per philosopher)
+        assert mock_mem_instance.record_position.call_count == 2
+        # Verify the recorded content is from the LAST messages
+        calls = mock_mem_instance.record_position.call_args_list
+        recorded_positions = [c[0][1] for c in calls]  # position_summary arg
+        assert any("Final thought" in p for p in recorded_positions)
+        assert any("Final wisdom" in p for p in recorded_positions)
+
+    @patch("core.graph.PhilosopherMemory")
+    def test_does_not_truncate_at_200_chars(self, mock_phil_mem):
+        """Positions longer than 200 chars should not be truncated at 200."""
+        mock_mem_instance = MagicMock()
+        mock_phil_mem.return_value = mock_mem_instance
+
+        long_content = "A" * 300
+        state = DialogueState(
+            messages=[
+                {"role": "Socrates", "content": long_content, "monologue": None},
+            ],
+            philosopher_1_id="socrates",
+            philosopher_2_id="confucius",
+            topic="Test",
+        )
+
+        _record_positions(state, "Test", "session-123")
+
+        recorded = mock_mem_instance.record_position.call_args[0][1]
+        assert len(recorded) >= 300  # Not truncated at 200
+
+
+# ---------------------------------------------------------------------------
+# Translator: handles all 6 philosophers
+# ---------------------------------------------------------------------------
+
+class TestTranslatorAllPhilosophers:
+    def test_includes_all_registered_philosophers(self):
+        """Translator should not skip any registered philosopher."""
+        messages = [
+            {"role": "user", "content": "What is history?"},
+            {"role": "Socrates", "content": "History teaches..."},
+            {"role": "Confucius", "content": "The ancients..."},
+            {"role": "Aristotle", "content": "Observation shows..."},
+            {"role": "Nietzsche", "content": "Will to power..."},
+            {"role": "Herodotus", "content": "I inquired..."},
+            {"role": "Sima Qian", "content": "The records show..."},
+        ]
+        result = format_conversation_for_translation(messages)
+        assert "INITIAL PROMPT" in result
+        assert "SOCRATES" in result
+        assert "CONFUCIUS" in result
+        assert "ARISTOTLE" in result
+        assert "NIETZSCHE" in result
+        assert "HERODOTUS" in result
+        assert "SIMA QIAN" in result
+
+    def test_still_excludes_system_messages(self):
+        messages = [
+            {"role": "system", "content": "Moderator context"},
+            {"role": "Aristotle", "content": "My view is..."},
+        ]
+        result = format_conversation_for_translation(messages)
+        assert "Moderator" not in result
+        assert "ARISTOTLE" in result
+
+
+# ---------------------------------------------------------------------------
+# Shared robust_invoke
+# ---------------------------------------------------------------------------
+
+class TestSharedRobustInvoke:
+    def test_success(self):
+        chain = MagicMock()
+        chain.invoke.return_value = "Hello world"
+        result, monologue = robust_invoke(chain, {"input": "test"}, "TestActor", 1)
+        assert result == "Hello world"
+        assert monologue is None
+
+    def test_none_chain(self):
+        result, monologue = robust_invoke(None, {"input": "test"}, "TestActor", 1)
+        assert result is None
+
+    def test_with_think_block(self):
+        chain = MagicMock()
+        chain.invoke.return_value = "<think>thinking</think>Visible"
+        result, monologue = robust_invoke(chain, {"input": "test"}, "TestActor", 1)
+        assert result == "Visible"
+        assert monologue == "thinking"
+
+    @patch("core.utils.time.sleep")
+    def test_retries_on_failure(self, mock_sleep):
+        chain = MagicMock()
+        chain.invoke.side_effect = [Exception("fail"), "recovered"]
+        result, monologue = robust_invoke(chain, {"input": "test"}, "TestActor", 1)
+        assert result == "recovered"
+
+    @patch("core.utils.time.sleep")
+    def test_permanent_failure(self, mock_sleep):
+        chain = MagicMock()
+        chain.invoke.side_effect = [Exception("fail")] * MAX_RETRIES
+        result, monologue = robust_invoke(chain, {"input": "test"}, "TestActor", 1)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_base_state(turn_count: int = 0) -> DialogueState:
+    return DialogueState(
+        messages=[],
+        memory_turns=[],
+        current_round=1,
+        total_rounds=3,
+        philosopher_1_id="socrates",
+        philosopher_2_id="confucius",
+        philosopher_1_name="Socrates",
+        philosopher_2_name="Confucius",
+        last_speaker_id="",
+        last_response="",
+        next_speaker_id="socrates",
+        speaker_intent="",
+        addressed_to="",
+        mode="philosophy",
+        topic="What is virtue?",
+        turn_count=turn_count,
+        is_complete=False,
+        error="",
+    )

--- a/tests/test_persona.py
+++ b/tests/test_persona.py
@@ -44,4 +44,6 @@ class TestCreateChain:
         overrides = {"socrates_philosophy": "Custom prompt."}
         chain = create_chain("socrates", mode="philosophy", prompt_overrides=overrides)
         assert chain is not None
-        mock_load.assert_called_once_with("socrates", mode="philosophy", prompt_overrides=overrides)
+        mock_load.assert_called_once_with(
+            "socrates", mode="philosophy", prompt_overrides=overrides, max_tokens_override=None,
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -101,3 +101,18 @@ class TestParseDirectionTag:
         cleaned, info = parse_direction_tag(text)
         assert info["next"] == "Sima Qian"
         assert info["intent"] == "address"
+
+    def test_without_intent_keyword(self):
+        """LLMs sometimes omit the INTENT: keyword — regex should still match."""
+        text = "I sought harmony, yes.\n[NEXT: Confucius | reflect]"
+        cleaned, info = parse_direction_tag(text)
+        assert cleaned == "I sought harmony, yes."
+        assert info["next"] == "Confucius"
+        assert info["intent"] == "reflect"
+
+    def test_without_intent_keyword_challenge(self):
+        text = "Did you not see?\n[NEXT: Socrates | challenge]"
+        cleaned, info = parse_direction_tag(text)
+        assert "[NEXT:" not in cleaned
+        assert info["next"] == "Socrates"
+        assert info["intent"] == "challenge"

--- a/translator.py
+++ b/translator.py
@@ -3,6 +3,7 @@
 import logging
 from typing import List, Dict, Any
 from core.config import load_llm_config_for_persona
+from core.registry import get_display_names
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
 
@@ -44,7 +45,8 @@ def format_conversation_for_translation(messages: List[Dict[str, Any]]) -> str:
         content = message.get("content", "")
         
         # We only want to translate the actual dialogue
-        if role not in ["USER", "SOCRATES", "CONFUCIUS"]:
+        valid_roles = {"USER"} | {name.upper() for name in get_display_names()}
+        if role not in valid_roles:
             continue
             
         if role == "USER":


### PR DESCRIPTION
## Summary

- **Full conversation context for philosophers** — removed the 6-turn sliding window so philosophers see the entire conversation history and always receive the original topic on every turn
- **Fixed direction tag regex** — tags now stripped correctly whether the LLM includes `INTENT:` keyword or not; intent (address, challenge, reflect, yield) displayed as meta text in the UI
- **Verbosity slider** — new max_tokens slider (100–800) in settings so users can control response length per conversation
- **Bug fixes** — `conversation_completed` always-true bug, translator/settings hard-coded to only 2 philosophers, SQLite connection leaks in PhilosopherMemory
- **Code consolidation** — duplicate `_robust_invoke` merged into shared `core/utils.py`, `load_dotenv()` moved to module-level
- **Streamlit Cloud ready** — secrets bridge for `st.secrets` → `os.environ`, pinned requirements, secrets template
- **149 tests passing** — 17 new tests covering memory awareness, topic injection, translator, and shared utilities

## Test plan

- [x] All 149 tests pass (`python -m pytest tests/ -v`)
- [x] Import chains verified (`from core.graph import run_agentic_conversation`)
- [x] Manual conversation test — direction tags stripped, intent displayed, topic maintained across rounds
- [x] Verbosity slider tested at different settings
- [ ] Deploy to Streamlit Community Cloud and verify secrets/auth work

🤖 Generated with [Claude Code](https://claude.com/claude-code)